### PR TITLE
Get rid of the env parameter to all Java functions.

### DIFF
--- a/examples/hello/HelloSpark.hs
+++ b/examples/hello/HelloSpark.hs
@@ -16,15 +16,14 @@ f2 :: Text -> Bool
 f2 s = "b" `Text.isInfixOf` s
 
 sparkMain :: JNIEnv -> JClass -> IO ()
-sparkMain envi _ = do
-    env <- attach envi
-    conf <- newSparkConf env "Hello sparkle!"
-    sc   <- newSparkContext env conf
-    rdd  <- textFile env sc "stack.yaml"
-    as   <- RDD.filter env (closure (static f1)) rdd
-    bs   <- RDD.filter env (closure (static f2)) rdd
-    numAs <- RDD.count env as
-    numBs <- RDD.count env bs
+sparkMain _ _ = do
+    conf <- newSparkConf "Hello sparkle!"
+    sc   <- newSparkContext conf
+    rdd  <- textFile sc "stack.yaml"
+    as   <- RDD.filter (closure (static f1)) rdd
+    bs   <- RDD.filter (closure (static f2)) rdd
+    numAs <- RDD.count as
+    numBs <- RDD.count bs
     putStrLn $ show numAs ++ " lines with a, "
             ++ show numBs ++ " lines with b."
 

--- a/examples/lda/SparkLDA.hs
+++ b/examples/lda/SparkLDA.hs
@@ -9,27 +9,26 @@ import Data.Text (Text)
 import Foreign.Java
 
 sparkMain :: JNIEnv -> JClass -> IO ()
-sparkMain envi _ = do
-    env <- attach envi
+sparkMain _ _ = do
     stopwords <- getStopwords
-    conf <- newSparkConf env "Spark Online Latent Dirichlet Allocation in Haskell!"
-    sc   <- newSparkContext env conf
-    sqlc <- newSQLContext env sc
-    docs <- wholeTextFiles env sc "nyt/"
-        >>= justValues env
-        >>= zipWithIndex env
-    docsRows <- toRows env docs
-    docsDF <- toDF env sqlc docsRows "docId" "text"
-    tok  <- newTokenizer env "text" "words"
-    tokenizedDF <- tokenize env tok docsDF
-    swr  <- newStopWordsRemover env stopwords "words" "filtered"
-    filteredDF <- removeStopWords env swr tokenizedDF
-    cv   <- newCountVectorizer env vocabSize "filtered" "features"
-    cvModel <- fitCV env cv filteredDF
-    countVectors <- toTokenCounts env cvModel filteredDF "docId" "features"
-    lda  <- newLDA env miniBatchFraction numTopics maxIterations
-    ldamodel  <- runLDA env lda countVectors
-    describeResults env ldamodel cvModel maxTermsPerTopic
+    conf <- newSparkConf "Spark Online Latent Dirichlet Allocation in Haskell!"
+    sc   <- newSparkContext conf
+    sqlc <- newSQLContext sc
+    docs <- wholeTextFiles sc "nyt/"
+        >>= justValues
+        >>= zipWithIndex
+    docsRows <- toRows docs
+    docsDF <- toDF sqlc docsRows "docId" "text"
+    tok  <- newTokenizer "text" "words"
+    tokenizedDF <- tokenize tok docsDF
+    swr  <- newStopWordsRemover stopwords "words" "filtered"
+    filteredDF <- removeStopWords swr tokenizedDF
+    cv   <- newCountVectorizer vocabSize "filtered" "features"
+    cvModel <- fitCV cv filteredDF
+    countVectors <- toTokenCounts cvModel filteredDF "docId" "features"
+    lda  <- newLDA miniBatchFraction numTopics maxIterations
+    ldamodel  <- runLDA lda countVectors
+    describeResults ldamodel cvModel maxTermsPerTopic
 
     where numTopics         = 10
           miniBatchFraction = 1

--- a/sparkle/sparkle.cabal
+++ b/sparkle/sparkle.cabal
@@ -24,7 +24,8 @@ library
     containers >=0.5,
     distributed-closure,
     inline-c >=0.5,
-    text >= 1.2,
-    vector >= 0.11
+    text >=1.2,
+    thread-local-storage >=0.1,
+    vector >=0.11
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/sparkle/src/Control/Distributed/Spark.hs
+++ b/sparkle/src/Control/Distributed/Spark.hs
@@ -17,249 +17,247 @@ import           Foreign.Java
 
 type SparkConf = JObject
 
-newSparkConf :: JNIEnv -> Text -> IO SparkConf
-newSparkConf env appname = do
-  cls <- findClass env "org/apache/spark/SparkConf"
-  setAppName <- getMethodID env cls "setAppName" "(Ljava/lang/String;)Lorg/apache/spark/SparkConf;"
-  cnf <- newObject env cls "()V" []
-  jname <- reflect env appname
-  _ <- callObjectMethod env cnf setAppName [JObject jname]
+newSparkConf :: Text -> IO SparkConf
+newSparkConf appname = do
+  cls <- findClass "org/apache/spark/SparkConf"
+  setAppName <- getMethodID cls "setAppName" "(Ljava/lang/String;)Lorg/apache/spark/SparkConf;"
+  cnf <- newObject cls "()V" []
+  jname <- reflect appname
+  _ <- callObjectMethod cnf setAppName [JObject jname]
   return cnf
 
 type SparkContext = JObject
 
-newSparkContext :: JNIEnv -> SparkConf -> IO SparkContext
-newSparkContext env conf = do
-  cls <- findClass env "org/apache/spark/api/java/JavaSparkContext"
-  newObject env cls "(Lorg/apache/spark/SparkConf;)V" [JObject conf]
+newSparkContext :: SparkConf -> IO SparkContext
+newSparkContext conf = do
+  cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
+  newObject cls "(Lorg/apache/spark/SparkConf;)V" [JObject conf]
 
 type RDD a = JObject
 
 parallelize
   :: Reflect [a] a'
-  => JNIEnv
-  -> SparkContext
+  => SparkContext
   -> [a]
   -> IO (RDD CInt)
-parallelize env sc xs = do
-    klass <- findClass env "org/apache/spark/api/java/JavaSparkContext"
-    method <- getMethodID env klass "parallelize" "(Ljava/util/List;)Lorg/apache/spark/api/java/JavaRDD;"
-    jxs <- arrayToList =<< reflect env xs
-    callObjectMethod env sc method [JObject jxs]
+parallelize sc xs = do
+    klass <- findClass "org/apache/spark/api/java/JavaSparkContext"
+    method <- getMethodID klass "parallelize" "(Ljava/util/List;)Lorg/apache/spark/api/java/JavaRDD;"
+    jxs <- arrayToList =<< reflect xs
+    callObjectMethod sc method [JObject jxs]
   where
     arrayToList jxs = do
-      klass <- findClass env "java/util/Arrays"
-      method <- getStaticMethodID env klass "asList" "([Ljava/lang/Object;)Ljava/util/List;"
-      callStaticObjectMethod env klass method [JObject jxs]
+      klass <- findClass "java/util/Arrays"
+      method <- getStaticMethodID klass "asList" "([Ljava/lang/Object;)Ljava/util/List;"
+      callStaticObjectMethod klass method [JObject jxs]
 
-filter :: (Reify a a', Typeable a) => JNIEnv -> Closure (a -> Bool) -> RDD a -> IO (RDD a)
-filter env clos rdd = do
-    f <- reflect env clos
-    klass <- findClass env "org/apache/spark/api/java/JavaRDD"
-    method <- getMethodID env klass "filter" "(Lorg/apache/spark/api/java/function/Function;)Lorg/apache/spark/api/java/JavaRDD;"
-    callObjectMethod env rdd method [JObject f]
+filter :: (Reify a a', Typeable a) => Closure (a -> Bool) -> RDD a -> IO (RDD a)
+filter clos rdd = do
+    f <- reflect clos
+    klass <- findClass "org/apache/spark/api/java/JavaRDD"
+    method <- getMethodID klass "filter" "(Lorg/apache/spark/api/java/function/Function;)Lorg/apache/spark/api/java/JavaRDD;"
+    callObjectMethod rdd method [JObject f]
 
-count :: JNIEnv -> RDD a -> IO Int64
-count env rdd = do
-  cls <- findClass env "org/apache/spark/api/java/JavaRDD"
-  mth <- getMethodID env cls "count" "()J"
-  callLongMethod env rdd mth []
+count :: RDD a -> IO Int64
+count rdd = do
+  cls <- findClass "org/apache/spark/api/java/JavaRDD"
+  mth <- getMethodID cls "count" "()J"
+  callLongMethod rdd mth []
 
 type PairRDD a b = JObject
 
-zipWithIndex :: JNIEnv -> RDD a -> IO (PairRDD Int64 a)
-zipWithIndex env rdd = do
-  cls <- findClass env "org/apache/spark/api/java/JavaRDD"
-  method <- getMethodID env cls "zipWithIndex" "()Lorg/apache/spark/api/java/JavaPairRDD;"
-  callObjectMethod env rdd method []
+zipWithIndex :: RDD a -> IO (PairRDD Int64 a)
+zipWithIndex rdd = do
+  cls <- findClass "org/apache/spark/api/java/JavaRDD"
+  method <- getMethodID cls "zipWithIndex" "()Lorg/apache/spark/api/java/JavaPairRDD;"
+  callObjectMethod rdd method []
 
-textFile :: JNIEnv -> SparkContext -> FilePath -> IO (RDD Text)
-textFile env sc path = do
-  jpath <- reflect env (Text.pack path)
-  cls <- findClass env "org/apache/spark/api/java/JavaSparkContext"
-  method <- getMethodID env cls "textFile" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
-  callObjectMethod env sc method [JObject jpath]
+textFile :: SparkContext -> FilePath -> IO (RDD Text)
+textFile sc path = do
+  jpath <- reflect (Text.pack path)
+  cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
+  method <- getMethodID cls "textFile" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
+  callObjectMethod sc method [JObject jpath]
 
-wholeTextFiles :: JNIEnv -> SparkContext -> Text -> IO (PairRDD Text Text)
-wholeTextFiles env sc uri = do
-  juri <- reflect env uri
-  cls <- findClass env "org/apache/spark/api/java/JavaSparkContext"
-  method <- getMethodID env cls "wholeTextFiles" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaPairRDD;"
-  callObjectMethod env sc method [JObject juri]
+wholeTextFiles :: SparkContext -> Text -> IO (PairRDD Text Text)
+wholeTextFiles sc uri = do
+  juri <- reflect uri
+  cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
+  method <- getMethodID cls "wholeTextFiles" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaPairRDD;"
+  callObjectMethod sc method [JObject juri]
 
-justValues :: JNIEnv -> PairRDD a b -> IO (RDD b)
-justValues env prdd = do
-  cls <- findClass env "org/apache/spark/api/java/JavaPairRDD"
-  values <- getMethodID env cls "values" "()Lorg/apache/spark/api/java/JavaRDD;"
-  callObjectMethod env prdd values []
+justValues :: PairRDD a b -> IO (RDD b)
+justValues prdd = do
+  cls <- findClass "org/apache/spark/api/java/JavaPairRDD"
+  values <- getMethodID cls "values" "()Lorg/apache/spark/api/java/JavaRDD;"
+  callObjectMethod prdd values []
 
 type SQLContext = JObject
 
-newSQLContext :: JNIEnv -> SparkContext -> IO SQLContext
-newSQLContext env sc = do
-  cls <- findClass env "org/apache/spark/sql/SQLContext"
-  newObject env cls "(Lorg/apache/spark/api/java/JavaSparkContext;)V" [JObject sc]
+newSQLContext :: SparkContext -> IO SQLContext
+newSQLContext sc = do
+  cls <- findClass "org/apache/spark/sql/SQLContext"
+  newObject cls "(Lorg/apache/spark/api/java/JavaSparkContext;)V" [JObject sc]
 
 type Row = JObject
 type DataFrame = JObject
 
-toRows :: JNIEnv -> PairRDD a b -> IO (RDD Row)
-toRows env prdd = do
-  cls <- findClass env "Helper"
-  mth <- getStaticMethodID env cls "toRows" "(Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/api/java/JavaRDD;"
-  callStaticObjectMethod env cls mth [JObject prdd]
+toRows :: PairRDD a b -> IO (RDD Row)
+toRows prdd = do
+  cls <- findClass "Helper"
+  mth <- getStaticMethodID cls "toRows" "(Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/api/java/JavaRDD;"
+  callStaticObjectMethod cls mth [JObject prdd]
 
-toDF :: JNIEnv -> SQLContext -> RDD Row -> Text -> Text -> IO DataFrame
-toDF env sqlc rdd s1 s2 = do
-  cls <- findClass env "Helper"
-  mth <- getStaticMethodID env cls "toDF" "(Lorg/apache/spark/sql/SQLContext;Lorg/apache/spark/api/java/JavaRDD;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
-  col1 <- reflect env s1
-  col2 <- reflect env s2
-  callStaticObjectMethod env cls mth [JObject sqlc, JObject rdd, JObject col1, JObject col2]
+toDF :: SQLContext -> RDD Row -> Text -> Text -> IO DataFrame
+toDF sqlc rdd s1 s2 = do
+  cls <- findClass "Helper"
+  mth <- getStaticMethodID cls "toDF" "(Lorg/apache/spark/sql/SQLContext;Lorg/apache/spark/api/java/JavaRDD;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
+  col1 <- reflect s1
+  col2 <- reflect s2
+  callStaticObjectMethod cls mth [JObject sqlc, JObject rdd, JObject col1, JObject col2]
 
 type RegexTokenizer = JObject
 
-newTokenizer :: JNIEnv -> Text -> Text -> IO RegexTokenizer
-newTokenizer env icol ocol = do
-  cls <- findClass env "org/apache/spark/ml/feature/RegexTokenizer"
-  tok0 <- newObject env cls "()V" []
+newTokenizer :: Text -> Text -> IO RegexTokenizer
+newTokenizer icol ocol = do
+  cls <- findClass "org/apache/spark/ml/feature/RegexTokenizer"
+  tok0 <- newObject cls "()V" []
   let patt = "\\p{L}+" :: Text
   let gaps = False
   let jgaps = if gaps then 1 else 0
-  jpatt <- reflect env patt
-  jicol <- reflect env icol
-  jocol <- reflect env ocol
-  helper <- findClass env "Helper"
-  setuptok <- getStaticMethodID env helper "setupTokenizer" "(Lorg/apache/spark/ml/feature/RegexTokenizer;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/apache/spark/ml/feature/RegexTokenizer;"
-  callStaticObjectMethod env helper setuptok [JObject tok0, JObject jicol, JObject jocol, JBoolean jgaps, JObject jpatt]
+  jpatt <- reflect patt
+  jicol <- reflect icol
+  jocol <- reflect ocol
+  helper <- findClass "Helper"
+  setuptok <- getStaticMethodID helper "setupTokenizer" "(Lorg/apache/spark/ml/feature/RegexTokenizer;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/apache/spark/ml/feature/RegexTokenizer;"
+  callStaticObjectMethod helper setuptok [JObject tok0, JObject jicol, JObject jocol, JBoolean jgaps, JObject jpatt]
 
-tokenize :: JNIEnv -> RegexTokenizer -> DataFrame -> IO DataFrame
-tokenize env tok df = do
-  cls <- findClass env "org/apache/spark/ml/feature/RegexTokenizer"
-  mth <- getMethodID env cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  callObjectMethod env tok mth [JObject df]
+tokenize :: RegexTokenizer -> DataFrame -> IO DataFrame
+tokenize tok df = do
+  cls <- findClass "org/apache/spark/ml/feature/RegexTokenizer"
+  mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
+  callObjectMethod tok mth [JObject df]
 
 type StopWordsRemover = JObject
 
-newStopWordsRemover :: JNIEnv -> [Text] -> Text -> Text -> IO StopWordsRemover
-newStopWordsRemover env stopwords icol ocol = do
-  cls <- findClass env "org/apache/spark/ml/feature/StopWordsRemover"
-  swr0 <- newObject env cls "()V" []
-  setSw <- getMethodID env cls "setStopWords" "([Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
-  jstopwords <- reflect env stopwords
-  swr1 <- callObjectMethod env swr0 setSw [JObject jstopwords]
-  setCS <- getMethodID env cls "setCaseSensitive" "(Z)Lorg/apache/spark/ml/feature/StopWordsRemover;"
-  swr2 <- callObjectMethod env swr1 setCS [JBoolean 0]
-  seticol <- getMethodID env cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
-  setocol <- getMethodID env cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
-  jicol <- reflect env icol
-  jocol <- reflect env ocol
-  swr3 <- callObjectMethod env swr2 seticol [JObject jicol]
-  callObjectMethod env swr3 setocol [JObject jocol]
+newStopWordsRemover :: [Text] -> Text -> Text -> IO StopWordsRemover
+newStopWordsRemover stopwords icol ocol = do
+  cls <- findClass "org/apache/spark/ml/feature/StopWordsRemover"
+  swr0 <- newObject cls "()V" []
+  setSw <- getMethodID cls "setStopWords" "([Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
+  jstopwords <- reflect stopwords
+  swr1 <- callObjectMethod swr0 setSw [JObject jstopwords]
+  setCS <- getMethodID cls "setCaseSensitive" "(Z)Lorg/apache/spark/ml/feature/StopWordsRemover;"
+  swr2 <- callObjectMethod swr1 setCS [JBoolean 0]
+  seticol <- getMethodID cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
+  setocol <- getMethodID cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
+  jicol <- reflect icol
+  jocol <- reflect ocol
+  swr3 <- callObjectMethod swr2 seticol [JObject jicol]
+  callObjectMethod swr3 setocol [JObject jocol]
 
-removeStopWords :: JNIEnv -> StopWordsRemover -> DataFrame -> IO DataFrame
-removeStopWords env sw df = do
-  cls <- findClass env "org/apache/spark/ml/feature/StopWordsRemover"
-  mth <- getMethodID env cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  callObjectMethod env sw mth [JObject df]
+removeStopWords :: StopWordsRemover -> DataFrame -> IO DataFrame
+removeStopWords sw df = do
+  cls <- findClass "org/apache/spark/ml/feature/StopWordsRemover"
+  mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
+  callObjectMethod sw mth [JObject df]
 
 type CountVectorizer = JObject
 
-newCountVectorizer :: JNIEnv -> Int32 -> Text -> Text -> IO CountVectorizer
-newCountVectorizer env vocSize icol ocol = do
-  cls <- findClass env "org/apache/spark/ml/feature/CountVectorizer"
-  cv  <- newObject env cls "()V" []
-  setInpc <- getMethodID env cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
-  jfiltered <- reflect env icol
-  cv' <- callObjectMethod env cv setInpc [JObject jfiltered]
-  setOutc <- getMethodID env cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
-  jfeatures <- reflect env ocol
-  cv'' <- callObjectMethod env cv' setOutc [JObject jfeatures]
-  setVocSize <- getMethodID env cls "setVocabSize" "(I)Lorg/apache/spark/ml/feature/CountVectorizer;"
-  callObjectMethod env cv'' setVocSize [JInt vocSize]
+newCountVectorizer :: Int32 -> Text -> Text -> IO CountVectorizer
+newCountVectorizer vocSize icol ocol = do
+  cls <- findClass "org/apache/spark/ml/feature/CountVectorizer"
+  cv  <- newObject cls "()V" []
+  setInpc <- getMethodID cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
+  jfiltered <- reflect icol
+  cv' <- callObjectMethod cv setInpc [JObject jfiltered]
+  setOutc <- getMethodID cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
+  jfeatures <- reflect ocol
+  cv'' <- callObjectMethod cv' setOutc [JObject jfeatures]
+  setVocSize <- getMethodID cls "setVocabSize" "(I)Lorg/apache/spark/ml/feature/CountVectorizer;"
+  callObjectMethod cv'' setVocSize [JInt vocSize]
 
 type CountVectorizerModel = JObject
 
-fitCV :: JNIEnv -> CountVectorizer -> DataFrame -> IO CountVectorizerModel
-fitCV env cv df = do
-  cls <- findClass env "org/apache/spark/ml/feature/CountVectorizer"
-  mth <- getMethodID env cls "fit" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/ml/feature/CountVectorizerModel;"
-  callObjectMethod env cv mth [JObject df]
+fitCV :: CountVectorizer -> DataFrame -> IO CountVectorizerModel
+fitCV cv df = do
+  cls <- findClass "org/apache/spark/ml/feature/CountVectorizer"
+  mth <- getMethodID cls "fit" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/ml/feature/CountVectorizerModel;"
+  callObjectMethod cv mth [JObject df]
 
 type SparkVector = JObject
 
-toTokenCounts :: JNIEnv -> CountVectorizerModel -> DataFrame -> Text -> Text -> IO (PairRDD CLong SparkVector)
-toTokenCounts env cvModel df col1 col2 = do
-  cls <- findClass env "org/apache/spark/ml/feature/CountVectorizerModel"
-  mth <- getMethodID env cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  df' <- callObjectMethod env cvModel mth [JObject df]
+toTokenCounts :: CountVectorizerModel -> DataFrame -> Text -> Text -> IO (PairRDD CLong SparkVector)
+toTokenCounts cvModel df col1 col2 = do
+  cls <- findClass "org/apache/spark/ml/feature/CountVectorizerModel"
+  mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
+  df' <- callObjectMethod cvModel mth [JObject df]
 
-  helper <- findClass env "Helper"
-  fromDF <- getStaticMethodID env helper "fromDF" "(Lorg/apache/spark/sql/DataFrame;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
-  fromRows <- getStaticMethodID env helper "fromRows" "(Lorg/apache/spark/api/java/JavaRDD;)Lorg/apache/spark/api/java/JavaPairRDD;"
-  jcol1 <- reflect env col1
-  jcol2 <- reflect env col2
-  rdd <- callStaticObjectMethod env helper fromDF [JObject df', JObject jcol1, JObject jcol2]
-  callStaticObjectMethod env helper fromRows [JObject rdd]
+  helper <- findClass "Helper"
+  fromDF <- getStaticMethodID helper "fromDF" "(Lorg/apache/spark/sql/DataFrame;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
+  fromRows <- getStaticMethodID helper "fromRows" "(Lorg/apache/spark/api/java/JavaRDD;)Lorg/apache/spark/api/java/JavaPairRDD;"
+  jcol1 <- reflect col1
+  jcol2 <- reflect col2
+  rdd <- callStaticObjectMethod helper fromDF [JObject df', JObject jcol1, JObject jcol2]
+  callStaticObjectMethod helper fromRows [JObject rdd]
 
 type LDA = JObject
 
-newLDA :: JNIEnv
-       -> Double                               -- ^ fraction of documents
+newLDA :: Double                               -- ^ fraction of documents
        -> Int32                                -- ^ number of topics
        -> Int32                                -- ^ maximum number of iterations
        -> IO LDA
-newLDA env frac numTopics maxIterations = do
-  cls <- findClass env "org/apache/spark/mllib/clustering/LDA"
-  lda <- newObject env cls "()V" []
+newLDA frac numTopics maxIterations = do
+  cls <- findClass "org/apache/spark/mllib/clustering/LDA"
+  lda <- newObject cls "()V" []
 
-  opti_cls <- findClass env "org/apache/spark/mllib/clustering/OnlineLDAOptimizer"
-  opti <- newObject env opti_cls "()V" []
-  setMiniBatch <- getMethodID env opti_cls "setMiniBatchFraction" "(D)Lorg/apache/spark/mllib/clustering/OnlineLDAOptimizer;"
-  opti' <- callObjectMethod env opti setMiniBatch [JDouble frac]
+  opti_cls <- findClass "org/apache/spark/mllib/clustering/OnlineLDAOptimizer"
+  opti <- newObject opti_cls "()V" []
+  setMiniBatch <- getMethodID opti_cls "setMiniBatchFraction" "(D)Lorg/apache/spark/mllib/clustering/OnlineLDAOptimizer;"
+  opti' <- callObjectMethod opti setMiniBatch [JDouble frac]
 
-  setOpti <- getMethodID env cls "setOptimizer" "(Lorg/apache/spark/mllib/clustering/LDAOptimizer;)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda' <- callObjectMethod env lda setOpti [JObject opti']
+  setOpti <- getMethodID cls "setOptimizer" "(Lorg/apache/spark/mllib/clustering/LDAOptimizer;)Lorg/apache/spark/mllib/clustering/LDA;"
+  lda' <- callObjectMethod lda setOpti [JObject opti']
 
-  setK <- getMethodID env cls "setK" "(I)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda'' <- callObjectMethod env lda' setK [JInt numTopics]
+  setK <- getMethodID cls "setK" "(I)Lorg/apache/spark/mllib/clustering/LDA;"
+  lda'' <- callObjectMethod lda' setK [JInt numTopics]
 
-  setMaxIter <- getMethodID env cls "setMaxIterations" "(I)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda''' <- callObjectMethod env lda'' setMaxIter [JInt maxIterations]
+  setMaxIter <- getMethodID cls "setMaxIterations" "(I)Lorg/apache/spark/mllib/clustering/LDA;"
+  lda''' <- callObjectMethod lda'' setMaxIter [JInt maxIterations]
 
-  setDocConc <- getMethodID env cls "setDocConcentration" "(D)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda'''' <- callObjectMethod env lda''' setDocConc [JDouble $ negate 1]
+  setDocConc <- getMethodID cls "setDocConcentration" "(D)Lorg/apache/spark/mllib/clustering/LDA;"
+  lda'''' <- callObjectMethod lda''' setDocConc [JDouble $ negate 1]
 
-  setTopicConc <- getMethodID env cls "setTopicConcentration" "(D)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda''''' <- callObjectMethod env lda'''' setTopicConc [JDouble $ negate 1]
+  setTopicConc <- getMethodID cls "setTopicConcentration" "(D)Lorg/apache/spark/mllib/clustering/LDA;"
+  lda''''' <- callObjectMethod lda'''' setTopicConc [JDouble $ negate 1]
 
   return lda'''''
 
 type LDAModel = JObject
 
-runLDA :: JNIEnv -> LDA -> PairRDD CLong SparkVector -> IO LDAModel
-runLDA env lda rdd = do
-  cls <- findClass env "Helper"
-  run <- getStaticMethodID env cls "runLDA" "(Lorg/apache/spark/mllib/clustering/LDA;Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/mllib/clustering/LDAModel;"
-  callStaticObjectMethod env cls run [JObject lda, JObject rdd]
+runLDA :: LDA -> PairRDD CLong SparkVector -> IO LDAModel
+runLDA lda rdd = do
+  cls <- findClass "Helper"
+  run <- getStaticMethodID cls "runLDA" "(Lorg/apache/spark/mllib/clustering/LDA;Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/mllib/clustering/LDAModel;"
+  callStaticObjectMethod cls run [JObject lda, JObject rdd]
 
-describeResults :: JNIEnv -> LDAModel -> CountVectorizerModel -> Int32 -> IO ()
-describeResults env lm cvm maxTerms = do
-  cls <- findClass env "Helper"
-  mth <- getStaticMethodID env cls "describeResults" "(Lorg/apache/spark/mllib/clustering/LDAModel;Lorg/apache/spark/ml/feature/CountVectorizerModel;I)V"
-  callStaticVoidMethod env cls mth [JObject lm, JObject cvm, JInt maxTerms]
+describeResults :: LDAModel -> CountVectorizerModel -> Int32 -> IO ()
+describeResults lm cvm maxTerms = do
+  cls <- findClass "Helper"
+  mth <- getStaticMethodID cls "describeResults" "(Lorg/apache/spark/mllib/clustering/LDAModel;Lorg/apache/spark/ml/feature/CountVectorizerModel;I)V"
+  callStaticVoidMethod cls mth [JObject lm, JObject cvm, JInt maxTerms]
 
-selectDF :: JNIEnv -> DataFrame -> [Text] -> IO DataFrame
-selectDF _ _ [] = error "selectDF: not enough arguments."
-selectDF env df (col:cols) = do
-  cls <- findClass env "org/apache/spark/sql/DataFrame"
-  mth <- getMethodID env cls "select" "(Ljava/lang/String;[Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
-  jcol <- reflect env col
-  jcols <- reflect env cols
-  callObjectMethod env df mth [JObject jcol, JObject jcols]
+selectDF :: DataFrame -> [Text] -> IO DataFrame
+selectDF _ [] = error "selectDF: not enough arguments."
+selectDF df (col:cols) = do
+  cls <- findClass "org/apache/spark/sql/DataFrame"
+  mth <- getMethodID cls "select" "(Ljava/lang/String;[Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
+  jcol <- reflect col
+  jcols <- reflect cols
+  callObjectMethod df mth [JObject jcol, JObject jcols]
 
-debugDF :: JNIEnv -> DataFrame -> IO ()
-debugDF env df = do
-  cls <- findClass env "org/apache/spark/sql/DataFrame"
-  mth <- getMethodID env cls "show" "()V"
-  callVoidMethod env df mth []
+debugDF :: DataFrame -> IO ()
+debugDF df = do
+  cls <- findClass "org/apache/spark/sql/DataFrame"
+  mth <- getMethodID cls "show" "()V"
+  callVoidMethod df mth []

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,8 @@ packages:
     commit: a0055dc39fe6d9cf2829786808b7ef6ecf3ed107
   extra-dep: true
 resolver: lts-5.1
+extra-deps:
+- thread-local-storage-0.1.0.3
 nix:
   enable: false
   shell-file: shell.nix


### PR DESCRIPTION
This extra parameter, which could have been hidden behind a reader monad
but at the cost of forcing all code, including pure code, to use
a monadic style, is now stored in a thread-local variable, using thread
local storage (TLS). We use the `thread-local-storage` package to achiev
that. Indeed, within a single thread, the env parameter is constant. So
instead of threading it through implicitly, we just don't thread it
through at all.

This patch further reduces the risk of tricky to resolve bugs that would
arise from one thread mistakenly sending the env parameter to another
thread, e.g. via a closure.
