### PR TITLE
Implement a gross hack to bypass call to exit() in hs_main().

### DIFF
--- a/sparkle/cbits/bootstrap.c
+++ b/sparkle/cbits/bootstrap.c
@@ -1,5 +1,6 @@
 #include <HsFFI.h>
 #include <pthread.h>
+#include <setjmp.h>
 #include "io_tweag_sparkle_Sparkle.h"
 
 extern HsPtr sparkle_apply(HsPtr a1, HsPtr a2);
@@ -41,6 +42,20 @@ JNIEXPORT jobject JNICALL Java_io_tweag_sparkle_Sparkle_apply
 	return sparkle_apply(bytes, args);
 }
 
+static jmp_buf bootstrap_env;
+
+/* A global callback defined in the GHC RTS. */
+extern void (*exitFn)(int);
+
+static void bypass_exit(int rc)
+{
+	/* If the exit code is 0, then jump the control flow back to
+	 * bootstrap(), because we don't want the RTS to call exit() -
+	 * we'd like to give Spark a chance to perform whatever
+	 * cleanup it needs. */
+	if(!rc) longjmp(bootstrap_env, 0);
+}
+
 JNIEXPORT void JNICALL Java_io_tweag_sparkle_Sparkle_bootstrap
   (JNIEnv * env, jclass klass)
 {
@@ -51,5 +66,13 @@ JNIEXPORT void JNICALL Java_io_tweag_sparkle_Sparkle_bootstrap
 	/* Don't init RTS before calling main(), because RTS can be
 	 * initialized only once. */
 	sparkle_init(env, 0);
+
+	exitFn = bypass_exit;
+	/* Set a control prompt just before calling main. If main()
+	 * calls longjmp(), then the exit code of the call to main()
+	 * below it must have been zero so just return without further
+	 * ceremony.
+	 */
+	if(setjmp(bootstrap_env)) return;
 	main(argc, pargv);
 }


### PR DESCRIPTION
A Haskell main() function is defined in terms of hs_main(), defined in
the RTS. This function never returns, because it always calls exit() at
some point. This prevents Spark from doing any cleanup, so we need to
avoid exiting so early like that. This patch uses longjmp()/setjmp() to
bypass the call to exit() if the exit code is 0.
