### PR TITLE
Remove the "Closure closed-world hack".

### DIFF
--- a/sparkle/src/Control/Distributed/Spark/Closure.hs
+++ b/sparkle/src/Control/Distributed/Spark/Closure.hs
@@ -18,13 +18,10 @@ module Control.Distributed.Spark.Closure (JFun1, apply) where
 
 import Control.Distributed.Closure
 import Control.Distributed.Closure.TH
-import Control.Applicative ((<|>))
 import Data.Binary (encode, decode)
-import Data.Maybe (fromJust)
 import qualified Data.ByteString.Lazy as LBS
 import Data.ByteString (ByteString)
-import Data.Text (Text)
-import Data.Typeable (Typeable, (:~:)(..), eqT, typeOf)
+import Data.Typeable (Typeable)
 import Foreign.JNI
 import Language.Java
 
@@ -47,60 +44,8 @@ foreign export ccall "sparkle_apply" apply
 type JFun1 a b = 'Class "io.tweag.sparkle.function.HaskellFunction" <> [Interp a, Interp b]
 type instance Interp ('Fun '[a] b) = JFun1 a b
 
--- Needs UndecidableInstances
-instance ( ty ~ Interp (Uncurry (Closure (a -> b)))
-         , ty ~ ('Class "io.tweag.sparkle.function.HaskellFunction" <> [ty1, ty2])
-         , Reflect a ty1
-         , Reify b ty2
-         ) =>
-         Reify (Closure (a -> b)) ty where
-  reify jobj = do
-      klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
-      field <- getFieldID klass "clos" "[B"
-      jpayload <- getObjectField jobj field
-      payload <- reify (unsafeCast jpayload)
-      return (bs2clos payload)
-
--- Needs UndecidableInstances
-instance ( ty ~ Interp (Uncurry (Closure (a -> b)))
-         , ty ~ ('Class "io.tweag.sparkle.function.HaskellFunction" <> [ty1, ty2])
-         , Reify a ty1
-         , Reflect b ty2
-         ) =>
-         Reflect (Closure (a -> b)) ty where
-  reflect f = do
-      klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
-      jpayload <- reflect (clos2bs (fromJust wrap))
-      fmap unsafeCast $ newObject klass "([B)V" [JObject jpayload]
-    where
-      -- TODO this type dispatch is a gross temporary hack! For until we get the
-      -- instance commented out below to work.
-      wrap :: Maybe (Closure (JObjectArray -> IO JObject))
-      wrap =
-        fmap (\Refl -> $(cstatic 'closFun1) `cap` $(cstatic 'dict1) `cap` f) (eqT :: Maybe ((a, b) :~: (Int, Int))) <|>
-        fmap (\Refl -> $(cstatic 'closFun1) `cap` $(cstatic 'dict2) `cap` f) (eqT :: Maybe ((a, b) :~: (Bool, Bool))) <|>
-        fmap (\Refl -> $(cstatic 'closFun1) `cap` $(cstatic 'dict3) `cap` f) (eqT :: Maybe ((a, b) :~: (ByteString, ByteString))) <|>
-        fmap (\Refl -> $(cstatic 'closFun1) `cap` $(cstatic 'dict4) `cap` f) (eqT :: Maybe ((a, b) :~: (Text, Text))) <|>
-        fmap (\Refl -> $(cstatic 'closFun1) `cap` $(cstatic 'dict5) `cap` f) (eqT :: Maybe ((a, b) :~: (Text, Bool))) <|>
-        error ("Due to TEMPORARY HACK - No static function from " ++
-               show (typeOf (undefined :: a)) ++
-               " to " ++
-               show (typeOf (undefined :: b)))
-
--- XXX Floating to top-level due to a limitation of -XStaticPointers.
---
--- See https://ghc.haskell.org/trac/ghc/ticket/11656.
-
-dict1 :: Dict (Reify Int ('Class "java.lang.Integer"), Reflect Int ('Class "java.lang.Integer"))
-dict2 :: Dict (Reify Bool ('Class  "java.lang.Boolean"), Reflect Bool ('Class  "java.lang.Boolean"))
-dict3 :: Dict (Reify ByteString ('Array ('Prim "byte")), Reflect ByteString ('Array ('Prim "byte")))
-dict4 :: Dict (Reify Text ('Class  "java.lang.String"), Reflect Text ('Class  "java.lang.String"))
-dict5 :: Dict (Reify Text ('Class  "java.lang.String"), Reflect Bool ('Class  "java.lang.Boolean"))
-dict1 = Dict
-dict2 = Dict
-dict3 = Dict
-dict4 = Dict
-dict5 = Dict
+pairDict :: Dict c1 -> Dict c2 -> Dict (c1, c2)
+pairDict Dict Dict = Dict
 
 closFun1
   :: forall a b ty1 ty2.
@@ -114,22 +59,49 @@ closFun1 Dict f args =
     reif = reify :: J ty1 -> IO a
     refl = reflect :: b -> IO (J ty2)
 
--- instance (Uncurry (Closure (a -> b)) ~ Fun '[a'] b', Reflect a a', Reify b b') =>
---          Reify (Closure (a -> b)) (Fun '[a'] b') where
---   reify jobj = do
---       klass <- findClass "io/tweag/sparkle/function/Function"
---       field <- getFieldID klass "clos" "[B"
---       jpayload <- getObjectField jobj field
---       payload <- reify jpayload
---       return (bs2clos payload)
---   reifyDict =
---       cmapDict `cap` reifyDictFun1 `cap` (cpairDict `cap` reflectDict `cap` reifyDict)
---
--- reifyDictFun1 :: (Reflect a a', Reify b b') :- Reify (Closure (a -> b)) (Fun '[a'] b')
--- reifyDictFun1 = Sub
-
 clos2bs :: Typeable a => Closure a -> ByteString
 clos2bs = LBS.toStrict . encode
 
 bs2clos :: Typeable a => ByteString -> Closure a
 bs2clos = decode . LBS.fromStrict
+
+-- TODO No Static (Reify/Reflect (Closure (a -> b)) ty) instances yet.
+
+-- Needs UndecidableInstances
+instance ( ty ~ Interp (Uncurry (Closure (a -> b)))
+         , ty ~ ('Class "io.tweag.sparkle.function.HaskellFunction" <> [ty1, ty2])
+         , Reflect a ty1
+         , Reify b ty2
+         , Typeable a
+         , Typeable b
+         , Typeable ty1
+         , Typeable ty2
+         ) =>
+         Reify (Closure (a -> b)) ty where
+  reify jobj = do
+      klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
+      field <- getFieldID klass "clos" "[B"
+      jpayload <- getObjectField jobj field
+      payload <- reify (unsafeCast jpayload)
+      return (bs2clos payload)
+
+-- Needs UndecidableInstances
+instance ( ty ~ Interp (Uncurry (Closure (a -> b)))
+         , ty ~ ('Class "io.tweag.sparkle.function.HaskellFunction" <> [ty1, ty2])
+         , Static (Reify a ty1)
+         , Static (Reflect b ty2)
+         , Typeable a
+         , Typeable b
+         , Typeable ty1
+         , Typeable ty2
+         ) =>
+         Reflect (Closure (a -> b)) ty where
+  reflect f = do
+      klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
+      jpayload <- reflect (clos2bs wrap)
+      fmap unsafeCast $ newObject klass "([B)V" [JObject jpayload]
+    where
+      wrap :: Closure (JObjectArray -> IO JObject)
+      wrap = $(cstatic 'closFun1) `cap`
+             ($(cstatic 'pairDict) `cap` closureDict `cap` closureDict) `cap`
+             f

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 - apps/lda
 - location:
     git: git@github.com:tweag/distributed-closure
-    commit: a0055dc39fe6d9cf2829786808b7ef6ecf3ed107
+    commit: 565c4da9b4706407b209aa7ebc896fd79ccd651d
   extra-dep: true
 resolver: lts-5.1
 extra-deps:


### PR DESCRIPTION
The Reify/Reflect instances for Closure are now open-world. Which means
that, unlike before where the instances were written assuming there's
a closed set of domain/codomain type pairs, the new instances make no
such closed set assumption.

This required adding a new feature to distributed-closure: Static
constraints, which are type class constraints that have an associated
Static instance. The Static instance provides static evidence
corresponding to the given (dynamic) evidence.

Known issue: distributed-closure still can't deal with equality
constraints well, so we can't write a Static instance for Reify/Reflect
of Closure (a -> b) yet. Which is annoying, because these equality
constraints are computationally irrelevant, so we should one way or
another just ignore them.