### PR TITLE
implement support for 2-arg function closures and use that to expose fold/reduce over RDDs

### DIFF
--- a/apps/rdd-ops/LICENSE
+++ b/apps/rdd-ops/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Tweag I/O Limited
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Tweag I/O nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apps/rdd-ops/RDDOps.hs
+++ b/apps/rdd-ops/RDDOps.hs
@@ -7,7 +7,6 @@ import Control.Distributed.Closure
 import Control.Distributed.Spark as RDD
 import Data.Monoid
 import qualified Data.Text as Text
-import Data.Text (Text)
 
 main :: IO ()
 main = do

--- a/apps/rdd-ops/RDDOps.hs
+++ b/apps/rdd-ops/RDDOps.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StaticPointers #-}
+
+module Main where
+
+import Control.Distributed.Closure
+import Control.Distributed.Spark as RDD
+import Data.Monoid
+import qualified Data.Text as Text
+import Data.Text (Text)
+
+main :: IO ()
+main = do
+    conf <- newSparkConf "RDD operations demo"
+    sc   <- newSparkContext conf
+    rdd  <- parallelize sc $ Text.words "The quick brown fox jumps over the lazy dog"
+    print =<< collect rdd
+    print =<< RDD.reduce (closure $ static (\a b -> b <> " " <> a)) rdd
+    print =<< collect =<< RDD.map (closure $ static Text.reverse) rdd
+    print =<< RDD.take rdd 3
+    print =<< collect =<< RDD.distinct rdd
+    print =<< RDD.fold (closure $ static (||)) False
+          =<< RDD.map (closure $ static (=="dog")) rdd

--- a/apps/rdd-ops/Setup.hs
+++ b/apps/rdd-ops/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/apps/rdd-ops/rdd-ops.cabal
+++ b/apps/rdd-ops/rdd-ops.cabal
@@ -1,0 +1,16 @@
+name:                rdd-ops
+version:             0.1
+license:             BSD3
+license-file:        LICENSE
+author:              Tweag I/O
+maintainer:          alp.mestanogullari@tweag.io
+copyright:           2016 Tweag I/O Ltd
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable sparkle-example-rddops
+  main-is: RDDOps.hs
+  build-depends: base >=4.7 && <5, distributed-closure, sparkle, text
+  default-language: Haskell2010
+  ghc-options: -dynamic -lpthread -threaded
+  ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ packages:
 - sparkle
 - apps/hello
 - apps/lda
+- apps/rdd-ops
 - location:
     git: git@github.com:tweag/distributed-closure
     commit: 565c4da9b4706407b209aa7ebc896fd79ccd651d


### PR DESCRIPTION
Note: I'm using `{-# OVERLAPPABLE #-}`/`{-# OVERLAPPING #-}` to avoid having GHC complain about overlapping instances. Aside from that, everything in this PR is a straightforward "port" of the 1 arg case.