### PR TITLE
Generic new / generic call.

### DIFF
--- a/inline-java/inline-java.cabal
+++ b/inline-java/inline-java.cabal
@@ -32,6 +32,7 @@ library
     containers >=0.5,
     distributed-closure,
     inline-c >=0.5,
+    singletons >= 2.0,
     text >=1.2,
     thread-local-storage >=0.1,
     vector >=0.11

--- a/inline-java/src/Foreign/JNI.hs
+++ b/inline-java/src/Foreign/JNI.hs
@@ -27,6 +27,8 @@ module Foreign.JNI
   , J(..)
   , upcast
   , unsafeCast
+  , generic
+  , unsafeUngeneric
   , JVM(..)
   , JNIEnv(..)
   , JMethodID(..)

--- a/inline-java/src/Foreign/JNI.hs
+++ b/inline-java/src/Foreign/JNI.hs
@@ -20,38 +20,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Foreign.JNI
-  ( -- * Java types
-    JType(..)
-  , type (<>)
-    -- * JNI types
-  , J(..)
-  , upcast
-  , unsafeCast
-  , generic
-  , unsafeUngeneric
-  , jtypeOf
-  , signature
-  , methodSignature
-  , JVM(..)
-  , JNIEnv(..)
-  , JMethodID(..)
-  , JFieldID(..)
-  , JValue(..)
-    -- * JNI defined object types
-  , JObject
-  , JClass
-  , JString
-  , JArray
-  , JObjectArray
-  , JBooleanArray
-  , JByteArray
-  , JCharArray
-  , JShortArray
-  , JIntArray
-  , JLongArray
-  , JFloatArray
-  , JDoubleArray
-  , JThrowable
+  ( module Foreign.JNI.Types
     -- * JNI functions
     -- ** Query functions
   , findClass

--- a/inline-java/src/Foreign/JNI.hs
+++ b/inline-java/src/Foreign/JNI.hs
@@ -29,6 +29,9 @@ module Foreign.JNI
   , unsafeCast
   , generic
   , unsafeUngeneric
+  , jtypeOf
+  , signature
+  , methodSignature
   , JVM(..)
   , JNIEnv(..)
   , JMethodID(..)

--- a/inline-java/src/Foreign/JNI.hs
+++ b/inline-java/src/Foreign/JNI.hs
@@ -212,10 +212,10 @@ callObjectMethod (coerce -> upcast -> obj) method args = withJNIEnv $ \env ->
                                            $(jmethodID method),
                                            $(jvalue *cargs)) } |]
 
-callBooleanMethod :: Coercible o (J a) => o -> JMethodID -> [JValue] -> IO Word8
+callBooleanMethod :: Coercible o (J a) => o -> JMethodID -> [JValue] -> IO Bool
 callBooleanMethod (coerce -> upcast -> obj) method args = withJNIEnv $ \env ->
     throwIfException env $
-    withArray args $ \cargs ->
+    fmap (toEnum . fromIntegral) $ withArray args $ \cargs ->
     [C.exp| jboolean {
       (*$(JNIEnv *env))->CallBooleanMethodA($(JNIEnv *env),
                                          $(jobject obj),

--- a/inline-java/src/Foreign/JNI/Types.hs
+++ b/inline-java/src/Foreign/JNI/Types.hs
@@ -1,19 +1,26 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}        -- For J a
 {-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Foreign.JNI.Types where
 
+import qualified Data.ByteString.Char8 as BS
+import Data.ByteString (ByteString)
 import Data.Coerce
 import Data.Int
 import Data.Map (fromList)
+import Data.Singletons (Sing, SingI(..), SomeSing(..), KProxy(..))
+import Data.Singletons.TypeLits (KnownSymbol, symbolVal)
 import Data.Word
 import Foreign.C (CChar)
 import Foreign.Ptr
@@ -45,6 +52,26 @@ data JType
   | Prim Symbol                                -- ^ Primitive type
   | Array JType                                -- ^ Array type
   | Generic JType [JType]                      -- ^ Parameterized (generic) type
+
+data instance Sing (a :: JType) where
+  SClass :: ByteString -> Sing ('Class sym)
+  SIface :: ByteString -> Sing ('Iface sym)
+  SPrim :: ByteString -> Sing ('Prim sym)
+  -- XXX SingI constraint temporary hack because GHC 7.10 has trouble inferring
+  -- this constraint in 'signature'.
+  SArray :: Sing ty -> Sing ('Array ty)
+  SGeneric :: Sing ty -> Sing tys -> Sing ('Generic ty tys)
+
+instance (KnownSymbol sym, SingI sym) => SingI ('Class (sym :: Symbol)) where
+  sing = SClass (BS.pack $ symbolVal (undefined :: proxy sym))
+instance (KnownSymbol sym, SingI sym) => SingI ('Iface (sym :: Symbol)) where
+  sing = SIface (BS.pack $ symbolVal (undefined :: proxy sym))
+instance (KnownSymbol sym, SingI sym) => SingI ('Prim (sym :: Symbol)) where
+  sing = SPrim (BS.pack $ symbolVal (undefined :: proxy sym))
+instance SingI ty => SingI ('Array ty) where
+  sing = SArray sing
+instance (SingI ty, SingI tys) => SingI ('Generic ty tys) where
+  sing = SGeneric sing sing
 
 -- | Shorthand for parametized Java types.
 type a <> g = 'Generic a g
@@ -81,7 +108,7 @@ data JValue
   | JLong Int64
   | JFloat Float
   | JDouble Double
-  | forall a o. Coercible o (J a) => JObject o
+  | forall a. SingI a => JObject {-# UNPACK#-} !(J a)
 
 instance Show JValue where
   show (JBoolean x) = "JBoolean " ++ show x

--- a/inline-java/src/Foreign/JNI/Types.hs
+++ b/inline-java/src/Foreign/JNI/Types.hs
@@ -52,6 +52,7 @@ data JType
   | Prim Symbol                                -- ^ Primitive type
   | Array JType                                -- ^ Array type
   | Generic JType [JType]                      -- ^ Parameterized (generic) type
+  | Void                                       -- ^ Void special type
 
 data instance Sing (a :: JType) where
   SClass :: ByteString -> Sing ('Class sym)
@@ -61,6 +62,7 @@ data instance Sing (a :: JType) where
   -- this constraint in 'signature'.
   SArray :: Sing ty -> Sing ('Array ty)
   SGeneric :: Sing ty -> Sing tys -> Sing ('Generic ty tys)
+  SVoid :: Sing 'Void
 
 instance (KnownSymbol sym, SingI sym) => SingI ('Class (sym :: Symbol)) where
   sing = SClass (BS.pack $ symbolVal (undefined :: proxy sym))
@@ -72,6 +74,8 @@ instance SingI ty => SingI ('Array ty) where
   sing = SArray sing
 instance (SingI ty, SingI tys) => SingI ('Generic ty tys) where
   sing = SGeneric sing sing
+instance SingI 'Void where
+  sing = SVoid
 
 -- | Shorthand for parametized Java types.
 type a <> g = 'Generic a g

--- a/inline-java/src/Foreign/JNI/Types.hs
+++ b/inline-java/src/Foreign/JNI/Types.hs
@@ -84,7 +84,7 @@ type a <> g = 'Generic a g
 newtype J (a :: JType) = J (Ptr (J a))
   deriving (Eq, Show, Storable)
 
-type role J nominal
+type role J representational
 
 -- | Any object can be cast to @Object@.
 upcast :: J a -> JObject

--- a/inline-java/src/Foreign/JNI/Types.hs
+++ b/inline-java/src/Foreign/JNI/Types.hs
@@ -12,7 +12,42 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Foreign.JNI.Types where
+module Foreign.JNI.Types
+  ( JType(..)
+  , Sing(..)
+  , type (<>)
+    -- * JNI types
+  , J(..)
+  , upcast
+  , unsafeCast
+  , generic
+  , unsafeUngeneric
+  , jtypeOf
+  , signature
+  , methodSignature
+  , JVM(..)
+  , JNIEnv(..)
+  , JMethodID(..)
+  , JFieldID(..)
+  , JValue(..)
+    -- * JNI defined object types
+  , JObject
+  , JClass
+  , JString
+  , JArray
+  , JObjectArray
+  , JBooleanArray
+  , JByteArray
+  , JCharArray
+  , JShortArray
+  , JIntArray
+  , JLongArray
+  , JFloatArray
+  , JDoubleArray
+  , JThrowable
+  -- * inline-c contexts
+  , jniCtx
+  ) where
 
 import qualified Data.ByteString.Char8 as BS
 import Data.ByteString (ByteString)

--- a/inline-java/src/Language/Java.hs
+++ b/inline-java/src/Language/Java.hs
@@ -217,7 +217,7 @@ withStatic [d|
     reify jobj = do
         klass <- findClass "java/lang/Boolean"
         method <- getMethodID klass "booleanValue" "()Z"
-        toEnum . fromIntegral <$> callBooleanMethod jobj method []
+        callBooleanMethod jobj method []
 
   instance Reflect Bool ('Class "java.lang.Boolean") where
     reflect x = new [JBoolean (fromIntegral (fromEnum x))]

--- a/inline-java/src/Language/Java.hs
+++ b/inline-java/src/Language/Java.hs
@@ -26,6 +26,8 @@ module Language.Java
   , Interp
   , Reify(..)
   , Reflect(..)
+  , Sing
+  , sing
   ) where
 
 import Control.Distributed.Closure
@@ -36,7 +38,7 @@ import Data.Int
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Unsafe as BS
-import Data.Singletons (Sing, SingI(..), fromSing)
+import Data.Singletons (SingI(..), fromSing)
 import qualified Data.Text.Foreign as Text
 import Data.Text (Text)
 import qualified Data.Vector.Storable as Vector

--- a/sparkle/sparkle.cabal
+++ b/sparkle/sparkle.cabal
@@ -36,6 +36,7 @@ library
     bytestring >=0.10,
     distributed-closure,
     inline-java >=0.1,
+    singletons >= 2.0,
     text >=1.2,
     vector >=0.11
   hs-source-dirs:      src

--- a/sparkle/src/Control/Distributed/Spark/Closure.hs
+++ b/sparkle/src/Control/Distributed/Spark/Closure.hs
@@ -122,9 +122,8 @@ instance ( JFun1 ty1 ty2 ~ Interp (Uncurry (Closure (a -> b)))
          ) =>
          Reflect (Closure (a -> b)) (JFun1 ty1 ty2) where
   reflect f = do
-      klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
       jpayload <- reflect (clos2bs wrap)
-      unsafeCast <$> newObject klass "([B)V" [coerce jpayload]
+      generic <$> new [coerce jpayload]
     where
       wrap :: Closure (JObjectArray -> IO JObject)
       wrap = $(cstatic 'closFun1) `cap`
@@ -164,9 +163,8 @@ instance ( ty ~ Interp (Uncurry (Closure (a -> b -> c)))
          ) =>
          Reflect (Closure (a -> b -> c)) ty where
   reflect f = do
-      klass <- findClass "io/tweag/sparkle/function/HaskellFunction2"
       jpayload <- reflect (clos2bs wrap)
-      unsafeCast <$> newObject klass "([B)V" [coerce jpayload]
+      generic <$> new [coerce jpayload]
     where
       wrap :: Closure (JObjectArray -> IO JObject)
       wrap = $(cstatic 'closFun2) `cap`

--- a/sparkle/src/Control/Distributed/Spark/Closure.hs
+++ b/sparkle/src/Control/Distributed/Spark/Closure.hs
@@ -124,7 +124,7 @@ instance ( JFun1 ty1 ty2 ~ Interp (Uncurry (Closure (a -> b)))
   reflect f = do
       klass <- findClass "io/tweag/sparkle/function/HaskellFunction"
       jpayload <- reflect (clos2bs wrap)
-      fmap unsafeCast $ newObject klass "([B)V" [JObject jpayload]
+      unsafeCast <$> newObject klass "([B)V" [coerce jpayload]
     where
       wrap :: Closure (JObjectArray -> IO JObject)
       wrap = $(cstatic 'closFun1) `cap`
@@ -166,7 +166,7 @@ instance ( ty ~ Interp (Uncurry (Closure (a -> b -> c)))
   reflect f = do
       klass <- findClass "io/tweag/sparkle/function/HaskellFunction2"
       jpayload <- reflect (clos2bs wrap)
-      fmap unsafeCast $ newObject klass "([B)V" [JObject jpayload]
+      unsafeCast <$> newObject klass "([B)V" [coerce jpayload]
     where
       wrap :: Closure (JObjectArray -> IO JObject)
       wrap = $(cstatic 'closFun2) `cap`

--- a/sparkle/src/Control/Distributed/Spark/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/Context.hs
@@ -38,9 +38,7 @@ newSparkContext conf = new [coerce conf]
 addFile :: SparkContext -> FilePath -> IO ()
 addFile sc fp = do
   jfp <- reflect (pack fp)
-  cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
-  method <- getMethodID cls "addFile" "(Ljava/lang/String;)V"
-  callVoidMethod sc method [coerce jfp]
+  call sc "addFile" [coerce jfp]
 
 -- | Returns the local filepath of the given filename that
 --   was "registered" using 'addFile'.

--- a/sparkle/src/Control/Distributed/Spark/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/Context.hs
@@ -1,22 +1,25 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.Context where
 
-import Data.Coerce
 import Data.Text (Text, pack, unpack)
 import Foreign.JNI
 import Language.Java
 
 newtype SparkConf = SparkConf (J ('Class "org.apache.spark.SparkConf"))
+instance Coercible SparkConf ('Class "org.apache.spark.SparkConf")
 
 newSparkConf :: Text -> IO SparkConf
 newSparkConf appname = do
   cls <- findClass "org/apache/spark/SparkConf"
   setAppName <- getMethodID cls "setAppName" "(Ljava/lang/String;)Lorg/apache/spark/SparkConf;"
-  cnf <- fmap unsafeCast $ newObject cls "()V" []
+  cnf <- unsafeUncoerce . coerce <$> newObject cls "()V" []
   jname <- reflect appname
-  _ <- callObjectMethod cnf setAppName [JObject jname]
-  return (coerce cnf)
+  _ <- callObjectMethod cnf setAppName [coerce jname]
+  return cnf
 
 confSet :: SparkConf -> Text -> Text -> IO ()
 confSet conf key value = do
@@ -24,15 +27,16 @@ confSet conf key value = do
   set <- getMethodID cls "set" "(Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/SparkConf;"
   jkey <- reflect key
   jval <- reflect value
-  _    <- callObjectMethod conf set [JObject jkey, JObject jval]
+  _    <- callObjectMethod conf set [coerce jkey, coerce jval]
   return ()
 
 newtype SparkContext = SparkContext (J ('Class "org.apache.spark.api.java.JavaSparkContext"))
+instance Coercible SparkContext ('Class "org.apache.spark.api.java.JavaSparkContext")
 
 newSparkContext :: SparkConf -> IO SparkContext
 newSparkContext conf = do
   cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
-  coerce . unsafeCast <$> newObject cls "(Lorg/apache/spark/SparkConf;)V" [JObject conf]
+  unsafeUncoerce . coerce <$> newObject cls "(Lorg/apache/spark/SparkConf;)V" [coerce conf]
 
 -- | Adds the given file to the pool of files to be downloaded
 --   on every worker node. Use 'getFile' on those nodes to
@@ -42,7 +46,7 @@ addFile sc fp = do
   jfp <- reflect (pack fp)
   cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
   method <- getMethodID cls "addFile" "(Ljava/lang/String;)V"
-  callVoidMethod sc method [JObject jfp]
+  callVoidMethod sc method [coerce jfp]
 
 -- | Returns the local filepath of the given filename that
 --   was "registered" using 'addFile'.
@@ -51,7 +55,7 @@ getFile filename = do
   jfilename <- reflect (pack filename)
   cls <- findClass "org/apache/spark/SparkFiles"
   method <- getStaticMethodID cls "get" "(Ljava/lang/String;)Ljava/lang/String;"
-  res <- callStaticObjectMethod cls method [JObject jfilename]
+  res <- callStaticObjectMethod cls method [coerce jfilename]
   fmap unpack $ reify (unsafeCast res)
 
 master :: SparkContext -> IO Text

--- a/sparkle/src/Control/Distributed/Spark/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/Context.hs
@@ -7,7 +7,6 @@
 module Control.Distributed.Spark.Context where
 
 import Data.Text (Text, pack, unpack)
-import Data.Singletons (Sing, sing)
 import Foreign.JNI
 import Language.Java
 

--- a/sparkle/src/Control/Distributed/Spark/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/Context.hs
@@ -7,6 +7,7 @@
 module Control.Distributed.Spark.Context where
 
 import Data.Text (Text, pack, unpack)
+import Data.Singletons (Sing, sing)
 import Foreign.JNI
 import Language.Java
 
@@ -47,10 +48,7 @@ addFile sc fp = do
 getFile :: FilePath -> IO FilePath
 getFile filename = do
   jfilename <- reflect (pack filename)
-  cls <- findClass "org/apache/spark/SparkFiles"
-  method <- getStaticMethodID cls "get" "(Ljava/lang/String;)Ljava/lang/String;"
-  res <- callStaticObjectMethod cls method [coerce jfilename]
-  fmap unpack $ reify (unsafeCast res)
+  fmap unpack . reify =<< callStatic (sing :: Sing "org.apache.spark.SparkFiles") "get" [coerce jfilename]
 
 master :: SparkContext -> IO Text
 master sc = do

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/CountVectorizer.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/CountVectorizer.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.ML.Feature.CountVectorizer where
 
 import Control.Distributed.Spark.PairRDD
 import Control.Distributed.Spark.SQL.DataFrame
-import Data.Coerce
 import Data.Int
 import Data.Text (Text)
 import Foreign.C.Types
@@ -13,6 +14,7 @@ import Foreign.JNI
 import Language.Java
 
 newtype CountVectorizer = CountVectorizer (J ('Class "org.apache.spark.ml.feature.CountVectorizer"))
+instance Coercible CountVectorizer ('Class "org.apache.spark.ml.feature.CountVectorizer")
 
 newCountVectorizer :: Int32 -> Text -> Text -> IO CountVectorizer
 newCountVectorizer vocSize icol ocol = do
@@ -20,34 +22,35 @@ newCountVectorizer vocSize icol ocol = do
   cv  <- newObject cls "()V" []
   setInpc <- getMethodID cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
   jfiltered <- reflect icol
-  cv' <- callObjectMethod cv setInpc [JObject jfiltered]
+  cv' <- callObjectMethod cv setInpc [coerce jfiltered]
   setOutc <- getMethodID cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/CountVectorizer;"
   jfeatures <- reflect ocol
-  cv'' <- callObjectMethod cv' setOutc [JObject jfeatures]
+  cv'' <- callObjectMethod cv' setOutc [coerce jfeatures]
   setVocSize <- getMethodID cls "setVocabSize" "(I)Lorg/apache/spark/ml/feature/CountVectorizer;"
-  coerce . unsafeCast <$> callObjectMethod cv'' setVocSize [JInt vocSize]
+  unsafeUncoerce . coerce <$> callObjectMethod cv'' setVocSize [JInt vocSize]
 
 newtype CountVectorizerModel = CountVectorizerModel (J ('Class "org.apache.spark.ml.feature.CountVectorizerModel"))
+instance Coercible CountVectorizerModel ('Class "org.apache.spark.ml.feature.CountVectorizerModel")
 
 fitCV :: CountVectorizer -> DataFrame -> IO CountVectorizerModel
 fitCV cv df = do
   cls <- findClass "org/apache/spark/ml/feature/CountVectorizer"
   mth <- getMethodID cls "fit" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/ml/feature/CountVectorizerModel;"
-  coerce . unsafeCast <$> callObjectMethod cv mth [JObject df]
+  unsafeUncoerce . coerce <$> callObjectMethod cv mth [coerce df]
 
 newtype SparkVector = SparkVector (J ('Class "org.apache.spark.mllib.linalg.Vector"))
+instance Coercible SparkVector ('Class "org.apache.spark.mllib.linalg.Vector")
 
 toTokenCounts :: CountVectorizerModel -> DataFrame -> Text -> Text -> IO (PairRDD CLong SparkVector)
 toTokenCounts cvModel df col1 col2 = do
   cls <- findClass "org/apache/spark/ml/feature/CountVectorizerModel"
   mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  df' <- callObjectMethod cvModel mth [JObject df]
+  df' <- callObjectMethod cvModel mth [coerce df]
 
   helper <- findClass "Helper"
   fromDF <- getStaticMethodID helper "fromDF" "(Lorg/apache/spark/sql/DataFrame;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
   fromRows <- getStaticMethodID helper "fromRows" "(Lorg/apache/spark/api/java/JavaRDD;)Lorg/apache/spark/api/java/JavaPairRDD;"
   jcol1 <- reflect col1
   jcol2 <- reflect col2
-  rdd <- callStaticObjectMethod helper fromDF [JObject df', JObject jcol1, JObject jcol2]
-  coerce . unsafeCast <$> callStaticObjectMethod helper fromRows [JObject rdd]
-
+  rdd <- callStaticObjectMethod helper fromDF [coerce df', coerce jcol1, coerce jcol2]
+  unsafeUncoerce . coerce <$> callStaticObjectMethod helper fromRows [coerce rdd]

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/CountVectorizer.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/CountVectorizer.hs
@@ -10,7 +10,6 @@ import Control.Distributed.Spark.RDD (RDD)
 import Control.Distributed.Spark.PairRDD
 import Control.Distributed.Spark.SQL.DataFrame
 import Data.Int
-import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.C.Types
 import Foreign.JNI

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
@@ -7,6 +7,7 @@
 module Control.Distributed.Spark.ML.Feature.RegexTokenizer where
 
 import Control.Distributed.Spark.SQL.DataFrame
+import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java
@@ -23,15 +24,15 @@ newTokenizer icol ocol = do
   jpatt <- reflect patt
   jicol <- reflect icol
   jocol <- reflect ocol
-  helper <- findClass "Helper"
-  setuptok <- getStaticMethodID helper "setupTokenizer" "(Lorg/apache/spark/ml/feature/RegexTokenizer;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/apache/spark/ml/feature/RegexTokenizer;"
-  unsafeUncoerce . coerce <$>
-    callStaticObjectMethod helper setuptok [ coerce tok0
-                                           , coerce jicol
-                                           , coerce jocol
-                                           , JBoolean jgaps
-                                           , coerce jpatt
-                                           ]
+  callStatic
+    (sing :: Sing "Helper")
+    "setupTokenizer"
+    [ coerce tok0
+    , coerce jicol
+    , coerce jocol
+    , JBoolean jgaps
+    , coerce jpatt
+    ]
 
 tokenize :: RegexTokenizer -> DataFrame -> IO DataFrame
 tokenize tok df = call tok "transform" [coerce df]

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.Distributed.Spark.ML.Feature.RegexTokenizer where
 
@@ -15,8 +16,7 @@ instance Coercible RegexTokenizer ('Class "org.apache.spark.ml.feature.RegexToke
 
 newTokenizer :: Text -> Text -> IO RegexTokenizer
 newTokenizer icol ocol = do
-  cls <- findClass "org/apache/spark/ml/feature/RegexTokenizer"
-  tok0 <- newObject cls "()V" []
+  tok0 :: RegexTokenizer <- new []
   let patt = "\\p{L}+" :: Text
   let gaps = False
   let jgaps = if gaps then 1 else 0
@@ -34,8 +34,4 @@ newTokenizer icol ocol = do
                                            ]
 
 tokenize :: RegexTokenizer -> DataFrame -> IO DataFrame
-tokenize tok df = do
-  cls <- findClass "org/apache/spark/ml/feature/RegexTokenizer"
-  mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  unsafeUncoerce . coerce <$>
-    callObjectMethod tok mth [coerce df]
+tokenize tok df = call tok "transform" [coerce df]

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/RegexTokenizer.hs
@@ -7,7 +7,6 @@
 module Control.Distributed.Spark.ML.Feature.RegexTokenizer where
 
 import Control.Distributed.Spark.SQL.DataFrame
-import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java

--- a/sparkle/src/Control/Distributed/Spark/ML/Feature/StopWordsRemover.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/Feature/StopWordsRemover.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.ML.Feature.StopWordsRemover where
 
 import Control.Distributed.Spark.SQL.DataFrame
-import Data.Coerce
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java
 
 newtype StopWordsRemover = StopWordsRemover (J ('Class "org.apache.spark.ml.feature.StopWordsRemover"))
+instance Coercible StopWordsRemover ('Class "org.apache.spark.ml.feature.StopWordsRemover")
 
 newStopWordsRemover :: [Text] -> Text -> Text -> IO StopWordsRemover
 newStopWordsRemover stopwords icol ocol = do
@@ -17,20 +19,19 @@ newStopWordsRemover stopwords icol ocol = do
   swr0 <- newObject cls "()V" []
   setSw <- getMethodID cls "setStopWords" "([Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
   jstopwords <- reflect stopwords
-  swr1 <- callObjectMethod swr0 setSw [JObject jstopwords]
+  swr1 <- callObjectMethod swr0 setSw [coerce jstopwords]
   setCS <- getMethodID cls "setCaseSensitive" "(Z)Lorg/apache/spark/ml/feature/StopWordsRemover;"
   swr2 <- callObjectMethod swr1 setCS [JBoolean 0]
   seticol <- getMethodID cls "setInputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
   setocol <- getMethodID cls "setOutputCol" "(Ljava/lang/String;)Lorg/apache/spark/ml/feature/StopWordsRemover;"
   jicol <- reflect icol
   jocol <- reflect ocol
-  swr3 <- callObjectMethod swr2 seticol [JObject jicol]
-  coerce . unsafeCast <$>
-    callObjectMethod swr3 setocol [JObject jocol]
-
+  swr3 <- callObjectMethod swr2 seticol [coerce jicol]
+  unsafeUncoerce . coerce <$>
+    callObjectMethod swr3 setocol [coerce jocol]
 
 removeStopWords :: StopWordsRemover -> DataFrame -> IO DataFrame
 removeStopWords sw df = do
   cls <- findClass "org/apache/spark/ml/feature/StopWordsRemover"
   mth <- getMethodID cls "transform" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  coerce . unsafeCast <$> callObjectMethod sw mth [JObject df]
+  unsafeUncoerce . coerce <$> callObjectMethod sw mth [coerce df]

--- a/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
@@ -9,7 +9,6 @@ module Control.Distributed.Spark.ML.LDA where
 import Control.Distributed.Spark.ML.Feature.CountVectorizer
 import Control.Distributed.Spark.PairRDD
 import Data.Int
-import Data.Singletons (Sing, sing)
 import Foreign.C.Types
 import Foreign.JNI
 import Language.Java

--- a/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.ML.LDA where
 
 import Control.Distributed.Spark.ML.Feature.CountVectorizer
 import Control.Distributed.Spark.PairRDD
-import Data.Coerce
 import Data.Int
 import Foreign.C.Types
 import Foreign.JNI
+import Language.Java
 
 newtype LDA = LDA (J ('Class "org.apache.spark.mllib.clustering.LDA"))
+instance Coercible LDA ('Class "org.apache.spark.mllib.clustering.LDA")
 
 newLDA :: Double                               -- ^ fraction of documents
        -> Int32                                -- ^ number of topics
@@ -26,7 +29,7 @@ newLDA frac numTopics maxIterations = do
   opti' <- callObjectMethod opti setMiniBatch [JDouble frac]
 
   setOpti <- getMethodID cls "setOptimizer" "(Lorg/apache/spark/mllib/clustering/LDAOptimizer;)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda' <- callObjectMethod lda setOpti [JObject opti']
+  lda' <- callObjectMethod lda setOpti [coerce opti']
 
   setK <- getMethodID cls "setK" "(I)Lorg/apache/spark/mllib/clustering/LDA;"
   lda'' <- callObjectMethod lda' setK [JInt numTopics]
@@ -38,21 +41,22 @@ newLDA frac numTopics maxIterations = do
   lda'''' <- callObjectMethod lda''' setDocConc [JDouble $ negate 1]
 
   setTopicConc <- getMethodID cls "setTopicConcentration" "(D)Lorg/apache/spark/mllib/clustering/LDA;"
-  lda''''' <- callObjectMethod lda'''' setTopicConc [JDouble $ negate 1]
+  lda''''' <- unsafeUncoerce . coerce <$> callObjectMethod lda'''' setTopicConc [JDouble $ negate 1]
 
-  return (coerce (unsafeCast lda'''''))
+  return lda'''''
 
 newtype LDAModel = LDAModel (J ('Class "org.apache.spark.mllib.clustering.LDAModel"))
+instance Coercible LDAModel ('Class "org.apache.spark.mllib.clustering.LDAModel")
 
 runLDA :: LDA -> PairRDD CLong SparkVector -> IO LDAModel
 runLDA lda rdd = do
   cls <- findClass "Helper"
   run <- getStaticMethodID cls "runLDA" "(Lorg/apache/spark/mllib/clustering/LDA;Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/mllib/clustering/LDAModel;"
-  coerce . unsafeCast <$>
-    callStaticObjectMethod cls run [JObject lda, JObject rdd]
+  unsafeUncoerce . coerce <$>
+    callStaticObjectMethod cls run [coerce lda, coerce rdd]
 
 describeResults :: LDAModel -> CountVectorizerModel -> Int32 -> IO ()
 describeResults lm cvm maxTerms = do
   cls <- findClass "Helper"
   mth <- getStaticMethodID cls "describeResults" "(Lorg/apache/spark/mllib/clustering/LDAModel;Lorg/apache/spark/ml/feature/CountVectorizerModel;I)V"
-  callStaticVoidMethod cls mth [JObject lm, JObject cvm, JInt maxTerms]
+  callStaticVoidMethod cls mth [coerce lm, coerce cvm, JInt maxTerms]

--- a/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
+++ b/sparkle/src/Control/Distributed/Spark/ML/LDA.hs
@@ -9,6 +9,7 @@ module Control.Distributed.Spark.ML.LDA where
 import Control.Distributed.Spark.ML.Feature.CountVectorizer
 import Control.Distributed.Spark.PairRDD
 import Data.Int
+import Data.Singletons (Sing, sing)
 import Foreign.C.Types
 import Foreign.JNI
 import Language.Java
@@ -37,11 +38,7 @@ newtype LDAModel = LDAModel (J ('Class "org.apache.spark.mllib.clustering.LDAMod
 instance Coercible LDAModel ('Class "org.apache.spark.mllib.clustering.LDAModel")
 
 runLDA :: LDA -> PairRDD CLong SparkVector -> IO LDAModel
-runLDA lda rdd = do
-  cls <- findClass "Helper"
-  run <- getStaticMethodID cls "runLDA" "(Lorg/apache/spark/mllib/clustering/LDA;Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/mllib/clustering/LDAModel;"
-  unsafeUncoerce . coerce <$>
-    callStaticObjectMethod cls run [coerce lda, coerce rdd]
+runLDA lda rdd = callStatic (sing :: Sing "Helper") "runLDA" [coerce lda, coerce rdd]
 
 describeResults :: LDAModel -> CountVectorizerModel -> Int32 -> IO ()
 describeResults lm cvm maxTerms = do

--- a/sparkle/src/Control/Distributed/Spark/PairRDD.hs
+++ b/sparkle/src/Control/Distributed/Spark/PairRDD.hs
@@ -17,20 +17,12 @@ newtype PairRDD a b = PairRDD (J ('Class "org.apache.spark.api.java.JavaPairRDD"
 instance Coercible (PairRDD a b) ('Class "org.apache.spark.api.java.JavaPairRDD")
 
 zipWithIndex :: RDD a -> IO (PairRDD Int64 a)
-zipWithIndex rdd = do
-  cls <- findClass "org/apache/spark/api/java/JavaRDD"
-  method <- getMethodID cls "zipWithIndex" "()Lorg/apache/spark/api/java/JavaPairRDD;"
-  unsafeUncoerce . coerce <$> callObjectMethod rdd method []
+zipWithIndex rdd = call rdd "zipWithIndex" []
 
 wholeTextFiles :: SparkContext -> Text -> IO (PairRDD Text Text)
 wholeTextFiles sc uri = do
   juri <- reflect uri
-  cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
-  method <- getMethodID cls "wholeTextFiles" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaPairRDD;"
-  unsafeUncoerce . coerce <$> callObjectMethod sc method [coerce juri]
+  call sc "wholeTextFiles" [coerce juri]
 
 justValues :: PairRDD a b -> IO (RDD b)
-justValues prdd = do
-  cls <- findClass "org/apache/spark/api/java/JavaPairRDD"
-  values <- getMethodID cls "values" "()Lorg/apache/spark/api/java/JavaRDD;"
-  unsafeUncoerce . coerce <$> callObjectMethod prdd values []
+justValues prdd = call prdd "values" []

--- a/sparkle/src/Control/Distributed/Spark/PairRDD.hs
+++ b/sparkle/src/Control/Distributed/Spark/PairRDD.hs
@@ -1,33 +1,36 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.PairRDD where
 
 import Control.Distributed.Spark.Context
 import Control.Distributed.Spark.RDD
-import Data.Coerce
 import Data.Int
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java
 
 newtype PairRDD a b = PairRDD (J ('Class "org.apache.spark.api.java.JavaPairRDD"))
+instance Coercible (PairRDD a b) ('Class "org.apache.spark.api.java.JavaPairRDD")
 
 zipWithIndex :: RDD a -> IO (PairRDD Int64 a)
 zipWithIndex rdd = do
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "zipWithIndex" "()Lorg/apache/spark/api/java/JavaPairRDD;"
-  coerce . unsafeCast <$> callObjectMethod rdd method []
+  unsafeUncoerce . coerce <$> callObjectMethod rdd method []
 
 wholeTextFiles :: SparkContext -> Text -> IO (PairRDD Text Text)
 wholeTextFiles sc uri = do
   juri <- reflect uri
   cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
   method <- getMethodID cls "wholeTextFiles" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaPairRDD;"
-  coerce . unsafeCast <$> callObjectMethod sc method [JObject juri]
+  unsafeUncoerce . coerce <$> callObjectMethod sc method [coerce juri]
 
 justValues :: PairRDD a b -> IO (RDD b)
 justValues prdd = do
   cls <- findClass "org/apache/spark/api/java/JavaPairRDD"
   values <- getMethodID cls "values" "()Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod prdd values []
+  unsafeUncoerce . coerce <$> callObjectMethod prdd values []

--- a/sparkle/src/Control/Distributed/Spark/RDD.hs
+++ b/sparkle/src/Control/Distributed/Spark/RDD.hs
@@ -11,7 +11,6 @@ import Control.Distributed.Closure
 import Control.Distributed.Spark.Closure ()
 import Control.Distributed.Spark.Context
 import Data.Int
-import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java

--- a/sparkle/src/Control/Distributed/Spark/RDD.hs
+++ b/sparkle/src/Control/Distributed/Spark/RDD.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.RDD where
 
 import Control.Distributed.Closure
 import Control.Distributed.Spark.Closure ()
 import Control.Distributed.Spark.Context
-import Data.Coerce
 import Data.Int
 import Data.Text (Text)
 import Foreign.JNI
@@ -15,6 +17,7 @@ import Language.Java
 import qualified Data.Text as Text
 
 newtype RDD a = RDD (J ('Class "org.apache.spark.api.java.JavaRDD"))
+instance Coercible (RDD a) ('Class "org.apache.spark.api.java.JavaRDD")
 
 parallelize
   :: Reflect a ty
@@ -25,12 +28,12 @@ parallelize sc xs = do
     klass <- findClass "org/apache/spark/api/java/JavaSparkContext"
     method <- getMethodID klass "parallelize" "(Ljava/util/List;)Lorg/apache/spark/api/java/JavaRDD;"
     jxs <- arrayToList =<< reflect xs
-    coerce . unsafeCast <$> callObjectMethod sc method [JObject jxs]
+    unsafeUncoerce . coerce <$> callObjectMethod sc method [coerce jxs]
   where
     arrayToList jxs = do
       klass <- findClass "java/util/Arrays"
       method <- getStaticMethodID klass "asList" "([Ljava/lang/Object;)Ljava/util/List;"
-      callStaticObjectMethod klass method [JObject jxs]
+      callStaticObjectMethod klass method [coerce jxs]
 
 
 filter
@@ -42,7 +45,7 @@ filter clos rdd = do
     f <- reflect clos
     klass <- findClass "org/apache/spark/api/java/JavaRDD"
     method <- getMethodID klass "filter" "(Lorg/apache/spark/api/java/function/Function;)Lorg/apache/spark/api/java/JavaRDD;"
-    coerce . unsafeCast <$> callObjectMethod rdd method [JObject f]
+    unsafeUncoerce . coerce <$> callObjectMethod rdd method [coerce f]
 
 map
   :: Reflect (Closure (a -> b)) ty
@@ -53,7 +56,7 @@ map clos rdd = do
     f <- reflect clos
     klass <- findClass "org/apache/spark/api/java/JavaRDD"
     method <- getMethodID klass "map" "(Lorg/apache/spark/api/java/function/Function;)Lorg/apache/spark/api/java/JavaRDD;"
-    coerce . unsafeCast <$> callObjectMethod rdd method [JObject f]
+    unsafeUncoerce . coerce <$> callObjectMethod rdd method [coerce f]
 
 fold
   :: (Reflect (Closure (a -> a -> a)) ty1, Reflect a ty2, Reify a ty2)
@@ -66,7 +69,7 @@ fold clos zero rdd = do
   jzero <- reflect zero
   klass <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID klass "fold" "(Ljava/lang/Object;Lorg/apache/spark/api/java/function/Function2;)Ljava/lang/Object;"
-  res <- unsafeCast <$> callObjectMethod rdd method [JObject jzero, JObject f]
+  res <- unsafeCast <$> callObjectMethod rdd method [coerce jzero, coerce f]
   reify res
 
 reduce
@@ -78,7 +81,7 @@ reduce clos rdd = do
   f <- reflect clos
   klass <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID klass "reduce" "(Lorg/apache/spark/api/java/function/Function2;)Ljava/lang/Object;"
-  res <- unsafeCast <$> callObjectMethod rdd method [JObject f]
+  res <- unsafeCast <$> callObjectMethod rdd method [coerce f]
   reify res
 
 aggregate
@@ -98,7 +101,7 @@ aggregate seqOp combOp zero rdd = do
   jzero <- reflect zero
   klass <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID klass "aggregate" "(Ljava/lang/Object;Lorg/apache/spark/api/java/function/Function2;Lorg/apache/spark/api/java/function/Function2;)Ljava/lang/Object;"
-  res <- unsafeCast <$> callObjectMethod rdd method [JObject jzero, JObject jseqOp, JObject jcombOp]
+  res <- unsafeCast <$> callObjectMethod rdd method [coerce jzero, coerce jseqOp, coerce jcombOp]
   reify res
 
 count :: RDD a -> IO Int64
@@ -132,25 +135,25 @@ textFile sc path = do
   jpath <- reflect (Text.pack path)
   cls <- findClass "org/apache/spark/api/java/JavaSparkContext"
   method <- getMethodID cls "textFile" "(Ljava/lang/String;)Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod sc method [JObject jpath]
+  unsafeUncoerce . coerce <$> callObjectMethod sc method [coerce jpath]
 
 distinct :: RDD a -> IO (RDD a)
 distinct r = do
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "distinct" "()Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod r method []
+  unsafeUncoerce . coerce <$> callObjectMethod r method []
 
 intersection :: RDD a -> RDD a -> IO (RDD a)
 intersection r r' = do
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "intersection" "(Lorg/apache/spark/api/java/JavaRDD;)Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod r method [JObject r']
+  unsafeUncoerce . coerce <$> callObjectMethod r method [coerce r']
 
 union :: RDD a -> RDD a -> IO (RDD a)
 union r r' = do
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "union" "(Lorg/apache/spark/api/java/JavaRDD;)Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod r method [JObject r']
+  unsafeUncoerce . coerce <$> callObjectMethod r method [coerce r']
 
 sample :: RDD a
        -> Bool   -- ^ sample with replacement (can elements be sampled
@@ -161,13 +164,13 @@ sample r withReplacement frac = do
   let rep = if withReplacement then 255 else 0
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "sample" "(ZD)Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callObjectMethod r method [JBoolean rep, JDouble frac]
+  unsafeUncoerce . coerce <$> callObjectMethod r method [JBoolean rep, JDouble frac]
 
 first :: Reify a ty => RDD a -> IO a
 first rdd = do
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "first" "()Ljava/lang/Object;"
-  res <- fmap (coerce . unsafeCast) $ callObjectMethod rdd method []
+  res <- unsafeUncoerce . coerce <$> callObjectMethod rdd method []
   reify res
 
 getNumPartitions :: RDD a -> IO Int32
@@ -181,4 +184,4 @@ saveAsTextFile rdd fp = do
   jfp <- reflect (Text.pack fp)
   cls <- findClass "org/apache/spark/api/java/JavaRDD"
   method <- getMethodID cls "saveAsTextFile" "(Ljava/lang/String;)V"
-  callVoidMethod rdd method [JObject jfp]
+  callVoidMethod rdd method [coerce jfp]

--- a/sparkle/src/Control/Distributed/Spark/RDD.hs
+++ b/sparkle/src/Control/Distributed/Spark/RDD.hs
@@ -94,10 +94,7 @@ aggregate seqOp combOp zero rdd = do
   reify (unsafeCast res)
 
 count :: RDD a -> IO Int64
-count rdd = do
-  cls <- findClass "org/apache/spark/api/java/JavaRDD"
-  mth <- getMethodID cls "count" "()J"
-  callLongMethod rdd mth []
+count rdd = call rdd "count" []
 
 collect :: Reify a ty => RDD a -> IO [a]
 collect rdd = do
@@ -140,14 +137,9 @@ first rdd = do
   reify (unsafeCast res)
 
 getNumPartitions :: RDD a -> IO Int32
-getNumPartitions rdd = do
-  cls <- findClass "org/apache/spark/api/java/JavaRDD"
-  method <- getMethodID cls "getNumPartitions" "()I"
-  callIntMethod rdd method []
+getNumPartitions rdd = call rdd "getNumPartitions" []
 
 saveAsTextFile :: RDD a -> FilePath -> IO ()
 saveAsTextFile rdd fp = do
   jfp <- reflect (Text.pack fp)
-  cls <- findClass "org/apache/spark/api/java/JavaRDD"
-  method <- getMethodID cls "saveAsTextFile" "(Ljava/lang/String;)V"
-  callVoidMethod rdd method [coerce jfp]
+  call rdd "saveAsTextFile" [coerce jfp]

--- a/sparkle/src/Control/Distributed/Spark/SQL/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/Context.hs
@@ -13,7 +13,4 @@ newtype SQLContext = SQLContext (J ('Class "org.apache.spark.sql.SQLContext"))
 instance Coercible SQLContext ('Class "org.apache.spark.sql.SQLContext")
 
 newSQLContext :: SparkContext -> IO SQLContext
-newSQLContext sc = do
-  cls <- findClass "org/apache/spark/sql/SQLContext"
-  unsafeUncoerce . coerce <$>
-    newObject cls "(Lorg/apache/spark/api/java/JavaSparkContext;)V" [coerce sc]
+newSQLContext sc = new [coerce sc]

--- a/sparkle/src/Control/Distributed/Spark/SQL/Context.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/Context.hs
@@ -1,17 +1,19 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.SQL.Context where
 
 import Control.Distributed.Spark.Context
-import Data.Coerce
 import Foreign.JNI
+import Language.Java
 
 newtype SQLContext = SQLContext (J ('Class "org.apache.spark.sql.SQLContext"))
+instance Coercible SQLContext ('Class "org.apache.spark.sql.SQLContext")
 
 newSQLContext :: SparkContext -> IO SQLContext
 newSQLContext sc = do
   cls <- findClass "org/apache/spark/sql/SQLContext"
-  coerce . unsafeCast <$>
-    newObject cls "(Lorg/apache/spark/api/java/JavaSparkContext;)V" [JObject sc]
-
+  unsafeUncoerce . coerce <$>
+    newObject cls "(Lorg/apache/spark/api/java/JavaSparkContext;)V" [coerce sc]

--- a/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
@@ -1,17 +1,19 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.SQL.DataFrame where
 
 import Control.Distributed.Spark.RDD
 import Control.Distributed.Spark.SQL.Context
 import Control.Distributed.Spark.SQL.Row
-import Data.Coerce
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java
 
 newtype DataFrame = DataFrame (J ('Class "org.apache.spark.sql.DataFrame"))
+instance Coercible DataFrame ('Class "org.apache.spark.sql.DataFrame")
 
 toDF :: SQLContext -> RDD Row -> Text -> Text -> IO DataFrame
 toDF sqlc rdd s1 s2 = do
@@ -19,11 +21,11 @@ toDF sqlc rdd s1 s2 = do
   mth <- getStaticMethodID cls "toDF" "(Lorg/apache/spark/sql/SQLContext;Lorg/apache/spark/api/java/JavaRDD;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
   col1 <- reflect s1
   col2 <- reflect s2
-  coerce . unsafeCast <$>
-    callStaticObjectMethod cls mth [ JObject sqlc
-                                   , JObject rdd
-                                   , JObject col1
-                                   , JObject col2
+  unsafeUncoerce . coerce <$>
+    callStaticObjectMethod cls mth [ coerce sqlc
+                                   , coerce rdd
+                                   , coerce col1
+                                   , coerce col2
                                    ]
 
 selectDF :: DataFrame -> [Text] -> IO DataFrame
@@ -33,8 +35,8 @@ selectDF df (col:cols) = do
   mth <- getMethodID cls "select" "(Ljava/lang/String;[Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
   jcol <- reflect col
   jcols <- reflect cols
-  coerce . unsafeCast <$>
-    callObjectMethod df mth [JObject jcol, JObject jcols]
+  unsafeUncoerce . coerce <$>
+    callObjectMethod df mth [coerce jcol, coerce jcols]
 
 debugDF :: DataFrame -> IO ()
 debugDF df = do
@@ -46,4 +48,4 @@ join :: DataFrame -> DataFrame -> IO DataFrame
 join d1 d2 = do
   cls <- findClass "org/apache/spark/sql/DataFrame"
   mth <- getMethodID cls "join" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  coerce . unsafeCast <$> callObjectMethod d1 mth [JObject d2]
+  unsafeUncoerce . coerce <$> callObjectMethod d1 mth [coerce d2]

--- a/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
@@ -8,6 +8,7 @@ module Control.Distributed.Spark.SQL.DataFrame where
 import Control.Distributed.Spark.RDD
 import Control.Distributed.Spark.SQL.Context
 import Control.Distributed.Spark.SQL.Row
+import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java
@@ -17,16 +18,9 @@ instance Coercible DataFrame ('Class "org.apache.spark.sql.DataFrame")
 
 toDF :: SQLContext -> RDD Row -> Text -> Text -> IO DataFrame
 toDF sqlc rdd s1 s2 = do
-  cls <- findClass "Helper"
-  mth <- getStaticMethodID cls "toDF" "(Lorg/apache/spark/sql/SQLContext;Lorg/apache/spark/api/java/JavaRDD;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
   col1 <- reflect s1
   col2 <- reflect s2
-  unsafeUncoerce . coerce <$>
-    callStaticObjectMethod cls mth [ coerce sqlc
-                                   , coerce rdd
-                                   , coerce col1
-                                   , coerce col2
-                                   ]
+  callStatic (sing :: Sing "Helper") "toDF" [coerce sqlc, coerce rdd, coerce col1, coerce col2]
 
 selectDF :: DataFrame -> [Text] -> IO DataFrame
 selectDF _ [] = error "selectDF: not enough arguments."

--- a/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
@@ -29,10 +29,7 @@ selectDF df (col:cols) = do
   call df "select" [coerce jcol, coerce jcols]
 
 debugDF :: DataFrame -> IO ()
-debugDF df = do
-  cls <- findClass "org/apache/spark/sql/DataFrame"
-  mth <- getMethodID cls "show" "()V"
-  callVoidMethod df mth []
+debugDF df = call df "show" []
 
 join :: DataFrame -> DataFrame -> IO DataFrame
 join d1 d2 = call d1 "join" [coerce d2]

--- a/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
@@ -31,12 +31,9 @@ toDF sqlc rdd s1 s2 = do
 selectDF :: DataFrame -> [Text] -> IO DataFrame
 selectDF _ [] = error "selectDF: not enough arguments."
 selectDF df (col:cols) = do
-  cls <- findClass "org/apache/spark/sql/DataFrame"
-  mth <- getMethodID cls "select" "(Ljava/lang/String;[Ljava/lang/String;)Lorg/apache/spark/sql/DataFrame;"
   jcol <- reflect col
   jcols <- reflect cols
-  unsafeUncoerce . coerce <$>
-    callObjectMethod df mth [coerce jcol, coerce jcols]
+  call df "select" [coerce jcol, coerce jcols]
 
 debugDF :: DataFrame -> IO ()
 debugDF df = do
@@ -45,7 +42,4 @@ debugDF df = do
   callVoidMethod df mth []
 
 join :: DataFrame -> DataFrame -> IO DataFrame
-join d1 d2 = do
-  cls <- findClass "org/apache/spark/sql/DataFrame"
-  mth <- getMethodID cls "join" "(Lorg/apache/spark/sql/DataFrame;)Lorg/apache/spark/sql/DataFrame;"
-  unsafeUncoerce . coerce <$> callObjectMethod d1 mth [coerce d2]
+join d1 d2 = call d1 "join" [coerce d2]

--- a/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/DataFrame.hs
@@ -8,7 +8,6 @@ module Control.Distributed.Spark.SQL.DataFrame where
 import Control.Distributed.Spark.RDD
 import Control.Distributed.Spark.SQL.Context
 import Control.Distributed.Spark.SQL.Row
-import Data.Singletons (Sing, sing)
 import Data.Text (Text)
 import Foreign.JNI
 import Language.Java

--- a/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Control.Distributed.Spark.SQL.Row where
 
 import Control.Distributed.Spark.PairRDD
 import Control.Distributed.Spark.RDD
-import Data.Coerce
 import Foreign.JNI
+import Language.Java
 
 newtype Row = Row (J ('Class "org.apache.spark.sql.Row"))
 
@@ -14,4 +15,4 @@ toRows :: PairRDD a b -> IO (RDD Row)
 toRows prdd = do
   cls <- findClass "Helper"
   mth <- getStaticMethodID cls "toRows" "(Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/api/java/JavaRDD;"
-  coerce . unsafeCast <$> callStaticObjectMethod cls mth [JObject prdd]
+  unsafeUncoerce . coerce <$> callStaticObjectMethod cls mth [coerce prdd]

--- a/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
@@ -6,13 +6,11 @@ module Control.Distributed.Spark.SQL.Row where
 
 import Control.Distributed.Spark.PairRDD
 import Control.Distributed.Spark.RDD
+import Data.Singletons (Sing, sing)
 import Foreign.JNI
 import Language.Java
 
 newtype Row = Row (J ('Class "org.apache.spark.sql.Row"))
 
 toRows :: PairRDD a b -> IO (RDD Row)
-toRows prdd = do
-  cls <- findClass "Helper"
-  mth <- getStaticMethodID cls "toRows" "(Lorg/apache/spark/api/java/JavaPairRDD;)Lorg/apache/spark/api/java/JavaRDD;"
-  unsafeUncoerce . coerce <$> callStaticObjectMethod cls mth [coerce prdd]
+toRows prdd = callStatic (sing :: Sing "Helper") "toRows" [coerce prdd]

--- a/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
+++ b/sparkle/src/Control/Distributed/Spark/SQL/Row.hs
@@ -6,7 +6,6 @@ module Control.Distributed.Spark.SQL.Row where
 
 import Control.Distributed.Spark.PairRDD
 import Control.Distributed.Spark.RDD
-import Data.Singletons (Sing, sing)
 import Foreign.JNI
 import Language.Java
 


### PR DESCRIPTION
This pair of functions abstracts over the low level JNI API functions.
Instead of getting a `ClassID`, getting a `MethodID`, constructing
a method signature to resolve any overloading and then calling
say `callIntMethod`, you can use `call`, which will do all of that under
the hood. Same for `new` and for `callStatic`.

One important thing to note is that Java object type indexes now have
a semantic role: they are used to generate method signatures at method
call sites. Different type indexes yield different method signatures. We
should document this somewhere, but not sure that Haddock is the best
place for it.