### PR TITLE
Add settings.gradle to force sparkle.jar filename

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sparkle'


### PR DESCRIPTION
This ensures that the jar file is correct when building from a git location via stack.