### PR TITLE
Vast reduction in JNI boilerplate bindings.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
   - curl -L --retry 3 https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - stack --no-terminal setup
   # XXX Roundabout method due to CircleCI parser bug.
-  - echo 'extra-include-dirsCOLON [/usr/lib/jvm/java-7-openjdk-amd64/include]' >> ~/.stack/config.yaml
+  - echo 'extra-include-dirsCOLON [/usr/lib/jvm/java-7-openjdk-amd64/include]' > ~/.stack/config.yaml
   - echo 'extra-lib-dirsCOLON [/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server]' >> ~/.stack/config.yaml
   - sed -i s/COLON/:/ ~/.stack/config.yaml
   - stack --no-terminal build --only-snapshot --prefetch


### PR DESCRIPTION
Generate all JNI bindings involving primitive types using CPP macros.
This includes all varations of call*Method, callStatic*Method,
get*ArrayElements, etc. This change amounts to a substantial reduction
in code size, while simultaneously making our coverage of the JNI API
much more complete.

In general TH is preferable to CPP macros, because they bring more
safety. But in this case, what we want amounts to textual substitution
across two different syntaxes. So TH wouldn't bring us any extra
safety over CPP, and CPP gets the job done with far less mechanism and
code.