### PR TITLE
Provide Dockerfile for non-linux environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Build environment for sparkle
+FROM ubuntu:xenial
+MAINTAINER Arnaud Bailly <arnaud@igitur.io>
+
+# install GHC
+# from https://github.com/freebroccolo/docker-haskell/blob/master/7.10/Dockerfile
+ENV LANG            C.UTF-8
+
+RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main' > /etc/apt/sources.list.d/ghc.list && \
+    echo 'deb http://download.fpcomplete.com/ubuntu xenial main'   > /etc/apt/sources.list.d/fpco.list  && \
+    # hvr keys
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
+    # fpco keys
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends netbase wget unzip cabal-install-1.22 ghc-7.10.3 happy-1.19.5 alex-3.1.4 \
+            stack zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++
+
+# install JDK
+# we need JDK because jre does not ship with libjvm.so...
+RUN apt-get install -y openjdk-8-jdk  && \
+    rm -rf /var/lib/apt/lists/*
+
+# install Gradle
+RUN wget -O /tmp/gradle-2.14-bin.zip https://services.gradle.org/distributions/gradle-2.14-bin.zip && \
+    unzip -d /opt /tmp/gradle-2.14-bin.zip
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/1.22/bin:/opt/gradle-2.14/bin:/opt/ghc/7.10.3/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH
+ENV GRADLE_HOME /opt/gradle-2.14
+

--- a/README.md
+++ b/README.md
@@ -71,6 +71,43 @@ a [whole cluster from scratch on EC2][spark-ec2].
 [spark-ec2]: http://spark.apache.org/docs/latest/ec2-scripts.html
 [nix]: http://nixos.org/nix
 
+### Non-Linux OSes
+
+Sparkle is not currently supported on non-linux OSes, e.g. Mac OS X or Windows. If you want to build and use it from a machine using
+such an OS, you can use the provided `Dockerfile` and build everything in [docker](http://docker.io):
+
+```
+$ docker build -t sparkle .
+```
+
+will create an image named `sparkle` containing everything that's needed to build sparkle and spark applications: GHC 7.10.3, stack,
+java 8, gradle.
+
+This image can be used to build sparkle then package and run applications:
+
+```
+$ docker run -ti -v $(pwd):/build -w build sparkle /bin/bash
+# stack build
+...
+```
+
+Note that you will need to edit the `stack.yaml` file to point to include directories and libraries for building C part that
+interacts with JVM:
+
+```
+extra-include-dirs:
+  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/include'
+  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/linux'
+extra-lib-dirs:
+  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server/'
+```
+
+Once everything is built you can generate a spark package and run it using `sparkle`'s command-line:
+
+```
+# stack exec sparkle package apps/hello/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/build/sparkle-example-hello/sparkle-example-hello
+```
+
 ## Troubleshooting
 
 ### `jvm` library or header files not found


### PR DESCRIPTION
I wanted to play with sparkle under Mac OS X which is not currently supported, hence I wrote a small Dockerfile that can be used to build sparkle itself and applications. Hope other people might find this useful.