### PR TITLE
Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,16 @@ MAINTAINER Arnaud Bailly <arnaud@igitur.io>
 # from https://github.com/freebroccolo/docker-haskell/blob/master/7.10/Dockerfile
 ENV LANG            C.UTF-8
 
-RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main' > /etc/apt/sources.list.d/ghc.list && \
-    echo 'deb http://download.fpcomplete.com/ubuntu xenial main'   > /etc/apt/sources.list.d/fpco.list  && \
-    # hvr keys
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
-    # fpco keys
+RUN echo 'deb http://download.fpcomplete.com/ubuntu xenial main' > /etc/apt/sources.list.d/fpco.list && \
+    echo 'deb http://ppa.launchpad.net/cwchien/gradle/ubuntu xenial main' > /etc/apt/sources.list.d/gradle.list && \
+    # fpco key
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D16156328D0E3056D885D0BD7CC6F019D06AF36 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends netbase wget unzip cabal-install-1.22 ghc-7.10.3 happy-1.19.5 alex-3.1.4 \
-            stack zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++
-
-# install JDK
-# we need JDK because jre does not ship with libjvm.so...
-RUN apt-get install -y openjdk-8-jdk  && \
-    rm -rf /var/lib/apt/lists/*
-
-# install Gradle
-RUN wget -O /tmp/gradle-2.14-bin.zip https://services.gradle.org/distributions/gradle-2.14-bin.zip && \
-    unzip -d /opt /tmp/gradle-2.14-bin.zip
-
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/1.22/bin:/opt/gradle-2.14/bin:/opt/ghc/7.10.3/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH
-ENV GRADLE_HOME /opt/gradle-2.14
-
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      gradle \
+      netbase \
+      # we need JDK because jre does not ship with libjvm.so...
+      openjdk-8-jdk \
+      stack

--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ such an OS, you can use the provided `Dockerfile` and build everything in [docke
 $ docker build -t sparkle .
 ```
 
-will create an image named `sparkle` containing everything that's needed to build sparkle and spark applications: GHC 7.10.3, stack,
-java 8, gradle.
+will create an image named `sparkle` containing everything that's
+needed to build sparkle and Spark applications: Stack, Java 8, Gradle.
 
 This image can be used to build sparkle then package and run applications:
 
 ```
-$ docker run -ti -v $(pwd):/build -w build sparkle /bin/bash
-# stack build
+# stack --docker --docker-image sparkle build
 ...
 ```
 
-Note that you will need to edit the `stack.yaml` file to point to include directories and libraries for building C part that
-interacts with JVM:
+Note that you will need to edit the `stack.yaml` file to point to
+include directories and libraries for building the C bits that
+interact with the JVM:
 
 ```
 extra-include-dirs:
@@ -105,7 +105,7 @@ extra-lib-dirs:
 Once everything is built you can generate a spark package and run it using `sparkle`'s command-line:
 
 ```
-# stack exec sparkle package apps/hello/.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/build/sparkle-example-hello/sparkle-example-hello
+# stack --docker --docker-image sparkle exec sparkle package sparkle-example-hello
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
* Don't install GHC - let `stack setup` do that (it'll pick a version
  that matches the `stack.yaml`).
* Install Gradle from PPA.
* Remove a few redundant packages.

It's now possible to `stack --docker build`. Updated README instructions
accordingly.