### PR TITLE
Nix in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
 # Build environment for sparkle
-FROM ubuntu:xenial
-MAINTAINER Arnaud Bailly <arnaud@igitur.io>
+FROM nixos/nix
+MAINTAINER Mathieu Boespflug <m@tweag.io>
 
-# install GHC
-# from https://github.com/freebroccolo/docker-haskell/blob/master/7.10/Dockerfile
-ENV LANG            C.UTF-8
-
-RUN echo 'deb http://download.fpcomplete.com/ubuntu xenial main' > /etc/apt/sources.list.d/fpco.list && \
-    echo 'deb http://ppa.launchpad.net/cwchien/gradle/ubuntu xenial main' > /etc/apt/sources.list.d/gradle.list && \
-    # fpco key
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D16156328D0E3056D885D0BD7CC6F019D06AF36 && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      ca-certificates \
-      gradle \
-      netbase \
-      # we need JDK because jre does not ship with libjvm.so...
-      openjdk-8-jdk \
-      stack
+ADD shell.nix /
+RUN nix-shell /shell.nix
+RUN cp -R /root/.nix-profile /nix-profile
+ENV \
+    ENV=/etc/profile \
+    PATH=/nix-profile/bin:/nix-profile/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
+    GIT_SSL_CAINFO=/nix-profile/etc/ssl/certs/ca-bundle.crt \
+    SSL_CERT_FILE=/nix-profile/etc/ssl/certs/ca-bundle.crt \
+    NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/
+RUN apk update && apk add ca-certificates xz make && chmod a+rwx /root
+ADD stack /

--- a/shell.nix
+++ b/shell.nix
@@ -28,7 +28,10 @@ let
       optional stdenv.isLinux glibcLocales ++
       [ ghc pkgconfig ];
 
-    STACK_IN_NIX_SHELL=1;
+    SSL_CERT_FILE=/nix-profile/etc/ssl/certs/ca-bundle.crt;
+
+    STACK_IN_NIXSHELL=1;
+    STACK_IN_CONTAINER=1;
     STACK_IN_NIX_EXTRA_ARGS =
       args.STACK_IN_NIX_EXTRA_ARGS or
       concatMap (pkg: ["--extra-lib-dirs=${pkg}/lib"
@@ -56,15 +59,13 @@ in
 buildStackProject {
   name = "sparkle";
   buildInputs =
-    [ gradle
-      openjdk
-      spark
+    [ # gradle
+      # openjdk
+      # spark
       which
       zlib
       # to fetch distributed-closure
       git
-      openssh
-      ghc
     ];
   inherit ghc;
   extraArgs = ["--extra-lib-dirs=${jvmlibdir}"];


### PR DESCRIPTION
This provides fixes so sparkle build can start in a nix-shell inside a docker container.

The only problem is that it hardcodes STACK_IN_CONTAINER=1; in the shell.nix
