### PR TITLE
Make the CI build be stack --docker based.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
     PATH: ~/.local/bin:~/spark/bin:$PATH
+  services:
+  - docker
 
 checkout:
   post:
@@ -11,22 +13,13 @@ dependencies:
   - "~/.stack"
 
   override:
-  # Work around who knows what ld.bfd bug.
-  - sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
-  - sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
-  - mkdir -p ~/spark
-  - curl -L --retry 3 http://d3kbcqa49mib13.cloudfront.net/spark-1.6.0-bin-hadoop2.6.tgz | tar xz -C ~/spark --strip-components=1
   - mkdir -p ~/.local/bin
   - curl -L --retry 3 https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  - stack --no-terminal setup
-  # XXX Roundabout method due to CircleCI parser bug.
-  - echo 'extra-include-dirsCOLON [/usr/lib/jvm/java-7-openjdk-amd64/include]' > ~/.stack/config.yaml
-  - echo 'extra-lib-dirsCOLON [/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server]' >> ~/.stack/config.yaml
-  - sed -i s/COLON/:/ ~/.stack/config.yaml
-  - stack --no-terminal --no-system-ghc build --only-snapshot --prefetch
+  - docker build -t sparkle .
+  - stack --no-terminal --docker --docker-image sparkle build --only-snapshot --prefetch
 
 test:
   override:
-  - stack --no-terminal --no-system-ghc build --pedantic
+  - stack --no-terminal --docker --docker-image sparkle build --pedantic
   # Test that packaging at least one example works fine.
-  - stack exec sparkle package sparkle-example-hello
+  - stack --no-terminal --docker --docker-image sparkle exec sparkle package sparkle-example-hello


### PR DESCRIPTION
In this way, we get to test that things still build fine in the Docker
image. As a side effect, we also get to exercise the nix-shell too,
since Docker uses it internally.

This change has the added benefit of making the CI steps shorter and
simpler.