### PR TITLE
Use Wercker for CI.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributors guide
+
+## Bug Reports
+
+Please [open an issue][new-issue].
+
+The more detailed your report, the faster it can be resolved. Once the
+bug has been resolved, the person responsible will tag the issue as
+_needs confirmation_ and assign the issue back to you. Once you have
+tested and confirmed that the issue is resolved, close the issue. If
+you are not a member of the project, you will be asked for
+confirmation and we will close it.
+
+[new-issue]: https://github.com/tweag/sparkle/issues/new
+
+## Code
+
+If you would like to contribute code to fix a bug, add a new feature,
+or otherwise improve sparkle, [pull requests][pull-requests] are most
+welcome. It's a good idea to [submit an issue][new-issue] to discuss
+the change before plowing into writing code.
+
+Please include a [changelog][changelog] entry and full Haddock
+documentation updates with your pull request.
+
+[changelog]: https://github.com/tweag/sparkle/blob/master/CHANGELOG.md
+[pull-requests]: https://help.github.com/articles/about-pull-requests/
+
+## Continuous integration
+
+Every time a pull request is updated, the [Wercker][wercker] service
+runs continuous integration checks inside a Docker build container.
+A declarative specification of the [build image][docker-build-img] is
+[here][dockerfile]. By design, the build image is *not* rebuilt at
+every new code push, because there is no way to use Docker registries
+as a cache for the result of building the Dockerfile to avoiding
+rebuilding the image all the time. This is because registries don't
+record what the build inputs for an image were.
+
+If you change the `Dockerfile` or any of its dependencies, you should
+[publish][docker-push] a new version of the image. It will be used as
+the environment for subsequent CI checks.
+
+[docker-build-img]: https://hub.docker.com/r/tweag/sparkle/
+[wercker]: http://www.wercker.com/
+[dockerfile]: https://github.com/tweag/sparkle/blob/master/Dockerfile
+[docker-push]: https://github.com/tweag/sparkle/blob/master/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN nix-shell /shell.nix --indirect --add-root /nix-shell-gc-root \
 RUN mkdir -p /usr/bin \
     && ln -s $(readlink -f $(which nix-shell)) /usr/bin/nix-shell
 
+RUN mkdir -p /etc/stack \
+    && echo -e 'nix:\n  enable: true' > /etc/stack/config.yaml
+
 # Workaround for Java getLocalHost() failure.
 # https://github.com/1science/docker-elasticsearch/issues/1#issuecomment-106307522
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,22 @@
+resolver: lts-6.21
+
 packages:
 - .
 - apps/hello
 - apps/lda
 - apps/rdd-ops
-resolver: lts-6.21
+
 extra-deps:
 - thread-local-storage-0.1.0.3
 - jni-0.1
 - jvm-0.1
+
 nix:
   # Requires Stack >= 1.2.
   shell-file: shell.nix
+
 docker:
   enable: false
+  image: tweag/sparkle
   run-args: ["--net=bridge"]
   stack-exe: image

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,16 @@
+box: tweag/sparkle
+
+build:
+  steps:
+  - script:
+      name: Dependencies
+      code: |
+        stack --no-terminal build --only-snapshot --prefetch
+  - script:
+      name: Project
+      code: |
+        stack --no-terminal build --pedantic
+  - script:
+      name: Package hello
+      code: |
+        stack --no-terminal exec sparkle package sparkle-example-hello


### PR DESCRIPTION
Circle CI is slow. Part of the reason is that it has more overhead
than it needs to. We have to manually build an uncacheable Docker
image (or pull it from a public registry), then manually run it,
having first manually installed Stack of course. All because in Circle
CI we always start from the same base VM image.

Wercker is noticably faster, but also simpler: provided a Docker image
with all the dependencies we need to build and test, just run the
build and test commands and you're done.