### PR TITLE
Address the true cause of "undefined symbol" errors in GHCi.

### DIFF
--- a/cbits/bootstrap.c
+++ b/cbits/bootstrap.c
@@ -1,24 +1,27 @@
+#include <errno.h>
 #include <HsFFI.h>
 #include <setjmp.h>
+#include <stdlib.h>
 #include "io_tweag_sparkle_Sparkle.h"
 
 extern HsPtr sparkle_apply(HsPtr a1, HsPtr a2);
 
-// main is provided when linking an executable. But sparkle is sometimes
-// loaded dynamically when no main symbol is provided. Typically, ghc
-// could load it when building code which uses ANN pragmas or template
-// haskell.
+// The real main() is provided when linking an executable. But sparkle
+// is sometimes loaded dynamically when no main symbol is provided.
+// Typically, ghc could load it when building code which uses ANN
+// pragmas or template haskell. So we provide a stub that we declare
+// "weak". It will be overridden with a real main() when linking an
+// executable.
 //
-// Because of this we make main a weak symbol. The man page of nm [1]
-// says:
-//
-//   When a weak undefined symbol is linked and the symbol is not
-//   defined, the value of the symbol is determined in a system-specific
-//   manner without error.
+// References:
 //
 // [1] https://linux.die.net/man/1/nm
 // [2] https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-g_t_0040code_007bweak_007d-function-attribute-3369
-extern int main(int argc, char *argv[]) __attribute__((weak));
+int __attribute__((weak)) main(int argc, char *argv[])
+{
+	fprintf(stderr, "%s: No main() function available.\n", argv[0]);
+	return ENOSYS;
+}
 
 static int argc = 0;
 static char* argv[] = { NULL }; /* or e.g { "+RTS", "-A1G", "-H1G", NULL }; */

--- a/shell.nix
+++ b/shell.nix
@@ -26,4 +26,11 @@ haskell.lib.buildStackProject {
   extraArgs = ["--extra-lib-dirs=${jvmlibdir}"];
   # XXX Workaround https://ghc.haskell.org/trac/ghc/ticket/11042.
   LD_LIBRARY_PATH = [jvmlibdir];
+  # XXX By default recent Nixpkgs passes hardening flags to the
+  # linker. The bindnow hardening flag is problematic, because it
+  # makes objects fail to load in GHCi, with strange errors about
+  # undefined symbols. See
+  # https://ghc.haskell.org/trac/ghc/ticket/12684. As a workaround,
+  # disable bindnow for now.
+  hardeningDisable = [ "bindnow" ];
 }


### PR DESCRIPTION
leapyear#12 was a fix for leapyear#11. But it turns out it's papering over the real issue. Namely that the reason we are seeing these problems is because of hardening flags passed to the linker in Nixpkgs. That explains why we were seeing this issue only inside a nix-shell (including inside the Docker image).

A better fix is therefore to simply disable this hardening. Otherwise, in general *every* extern symbol would likewise have to be marked with `attributed((weak))`, which sounds like a semantic abuse. In particular, even after applying leapyear#12, `stack ghci` still fails because of other symbols.

See https://ghc.haskell.org/trac/ghc/ticket/12684 and https://ghc.haskell.org/trac/ghc/ticket/12684. It may be that ultimately GHC ought to be able to cope with hardening flags. So this is a workaround for what amounts to a GHC bug.