### PR TITLE
Intero support.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ haskell.lib.buildStackProject {
   name = "sparkle";
   buildInputs =
     [ gradle
+      ncurses5 # For intero
       openjdk
       spark
       which


### PR DESCRIPTION
Involves simply having enough header files available in the nix shell.

Depends on #66.