### PR TITLE
Allow impure functions in sparkle bindings.

### DIFF
--- a/src/Control/Distributed/Spark/PairRDD.hs
+++ b/src/Control/Distributed/Spark/PairRDD.hs
@@ -6,6 +6,8 @@
 
 module Control.Distributed.Spark.PairRDD where
 
+import Control.Distributed.Closure
+import Control.Distributed.Spark.Closure
 import Control.Distributed.Spark.Context
 import Control.Distributed.Spark.RDD
 import Data.Int
@@ -25,3 +27,9 @@ wholeTextFiles sc uri = do
 
 justValues :: PairRDD a b -> IO (RDD b)
 justValues prdd = call prdd "values" []
+
+keyByIO :: Reflect (IOFun (Closure (v -> IO k))) ty1
+        => Closure (v -> IO k) -> RDD v -> IO (PairRDD k v)
+keyByIO byKeyOp rdd = do
+    jbyKeyOp <- reflect $ IOFun byKeyOp
+    call rdd "keyBy" [ coerce jbyKeyOp ]

--- a/src/Control/Distributed/Spark/RDD.hs
+++ b/src/Control/Distributed/Spark/RDD.hs
@@ -11,6 +11,7 @@ module Control.Distributed.Spark.RDD
   , repartition
   , filter
   , map
+  , mapIO
   , fold
   , reduce
   , aggregate
@@ -31,7 +32,7 @@ module Control.Distributed.Spark.RDD
 
 import Prelude hiding (filter, map, take)
 import Control.Distributed.Closure
-import Control.Distributed.Spark.Closure ()
+import Control.Distributed.Spark.Closure (IOFun(..))
 import Control.Distributed.Spark.Context
 import Data.ByteString (ByteString)
 import Data.Int
@@ -77,6 +78,15 @@ map
   -> IO (RDD b)
 map clos rdd = do
     f <- reflect clos
+    call rdd "map" [coerce f]
+
+mapIO
+  :: Reflect (IOFun (Closure (a -> IO b))) ty
+  => Closure (a -> IO b)
+  -> RDD a
+  -> IO (RDD b)
+mapIO clos rdd = do
+    f <- reflect $ IOFun clos
     call rdd "map" [coerce f]
 
 fold


### PR DESCRIPTION
Here goes another perhaps debatable PR.

The use case for `keyByIO` was appending to each record a key which was randomly generated, and using the random number generator required effects. This was later avoid by using `mapPartitions` instead.

The use case for `mapIO` is to convert some `RDD a` into `RDD Row`, which requires some bindings in the IO monad to create the Rows. 