### PR TITLE
mapPartitions and mapPartitionsWithIndex.

### DIFF
--- a/sparkle.cabal
+++ b/sparkle.cabal
@@ -51,12 +51,17 @@ library
     base >=4.8 && <5,
     binary >=0.7,
     bytestring >=0.10,
+    choice >= 0.1,
     distributed-closure >=0.3,
     jni >=0.1,
     jvm >=0.1,
     singletons >= 2.0,
+    streaming >= 0.1,
     text >=1.2,
     vector >=0.11
+  if impl(ghc > 8.0.1)
+    build-depends:
+      jvm-streaming >= 0.1
   hs-source-dirs: src
   default-language: Haskell2010
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -7,10 +7,12 @@ packages:
 - apps/rdd-ops
 - apps/argv
 extra-deps:
-- thread-local-storage-0.1.0.3
+- choice-0.1.1.0
 - jni-0.2.2
 - jvm-0.1.2
-- inline-java-0.6
+- jvm-streaming-0.1
+- inline-java-0.6.1
+- thread-local-storage-0.1.0.3
 
 explicit-setup-deps:
   bench: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,10 @@ packages:
 - apps/rdd-ops
 - apps/argv
 extra-deps:
-- thread-local-storage-0.1.0.3
+- choice-0.1.1.0
 - jni-0.2.2
 - jvm-0.1.2
+- thread-local-storage-0.1.0.3
 
 nix:
   # Requires Stack >= 1.2.


### PR DESCRIPTION
Uses the new `jvm-streaming` package under the hood. Note that these
functions are definable even without depending on `jvm-streaming` at
all. But only usable if the instances defined in `jvm-streaming` are in
scope. Since that package can only build on GHC >= 8.0.2, it means we
intentionally export the same API for all compiler versions (a good
thing), even if some of the API can't be used without a newer compiler.

This does not include redefining `aggregate` like #77 does. That can be
done as part of a separate PR, if the benchmarks warrant it.