### PR TITLE
Use latest thread-local-storage release.

### DIFF
--- a/apps/argv/argv.cabal
+++ b/apps/argv/argv.cabal
@@ -12,5 +12,5 @@ executable sparkle-example-argv
   main-is: Argv.hs
   build-depends: base >=4.7 && <5, distributed-closure, sparkle, text, vector
   default-language: Haskell2010
-  ghc-options: -dynamic -lpthread -threaded
+  ghc-options: -dynamic -threaded
   ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/apps/dataframe/dataframe.cabal
+++ b/apps/dataframe/dataframe.cabal
@@ -11,6 +11,6 @@ executable sparkle-example-dataframe
   main-is: Main.hs
   build-depends:       base >=4.7 && <5, distributed-closure, sparkle, text
   default-language:    Haskell2010
-  ghc-options: -dynamic -lpthread -threaded
+  ghc-options: -dynamic -threaded
   if !os(darwin)
     ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/apps/hello/hello.cabal
+++ b/apps/hello/hello.cabal
@@ -12,5 +12,5 @@ executable sparkle-example-hello
   main-is: HelloSpark.hs
   build-depends: base >=4.7 && <5, distributed-closure, sparkle, text, vector
   default-language: Haskell2010
-  ghc-options: -dynamic -lpthread -threaded
+  ghc-options: -dynamic -threaded
   ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/apps/lda/lda.cabal
+++ b/apps/lda/lda.cabal
@@ -12,5 +12,5 @@ executable sparkle-example-lda
   main-is: SparkLDA.hs
   build-depends:       base >=4.7 && <5, distributed-closure, sparkle, text
   default-language:    Haskell2010
-  ghc-options: -dynamic -lpthread -threaded
+  ghc-options: -dynamic -threaded
   ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/apps/rdd-ops/rdd-ops.cabal
+++ b/apps/rdd-ops/rdd-ops.cabal
@@ -12,5 +12,5 @@ executable sparkle-example-rddops
   main-is: RDDOps.hs
   build-depends: base >=4.7 && <5, distributed-closure, sparkle, text
   default-language: Haskell2010
-  ghc-options: -dynamic -lpthread -threaded
+  ghc-options: -dynamic -threaded
   ld-options: -pie -Wl,-z,origin -Wl,-rpath,$ORIGIN

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@ extra-deps:
 - jvm-0.1.2
 - jvm-streaming-0.1
 - inline-java-0.6.1
-- thread-local-storage-0.1.0.3
+- thread-local-storage-0.1.1
 
 explicit-setup-deps:
   bench: true


### PR DESCRIPTION
This enables us to drop -lpthread in ghc-options in all our apps.