### PR TITLE
Move parallelize, textFile and binaryRecords to Context.

### DIFF
--- a/src/Control/Distributed/Spark/Context.hs
+++ b/src/Control/Distributed/Spark/Context.hs
@@ -21,9 +21,17 @@ module Control.Distributed.Spark.Context
   , addFile
   , getFile
   , master
+  -- * RDD creation
+  , parallelize
+  , binaryRecords
+  , textFile
   ) where
 
-import Data.Text (Text, pack, unpack)
+import Data.Int (Int32)
+import Data.ByteString (ByteString)
+import qualified Data.Text as Text
+import Data.Text (Text)
+import Control.Distributed.Spark.RDD
 import Language.Java
 
 newtype SparkConf = SparkConf (J ('Class "org.apache.spark.SparkConf"))
@@ -48,29 +56,58 @@ instance Coercible SparkContext ('Class "org.apache.spark.api.java.JavaSparkCont
 newSparkContext :: SparkConf -> IO SparkContext
 newSparkContext conf = new [coerce conf]
 
--- | Adds the given file to the pool of files to be downloaded
---   on every worker node. Use 'getFile' on those nodes to
---   get the (local) file path of that file in order to read it.
-addFile :: SparkContext -> FilePath -> IO ()
-addFile sc fp = do
-  jfp <- reflect (pack fp)
-  call sc "addFile" [coerce jfp]
-
--- | Returns the local filepath of the given filename that
---   was "registered" using 'addFile'.
-getFile :: FilePath -> IO FilePath
-getFile filename = do
-  jfilename <- reflect (pack filename)
-  fmap unpack . reify =<< callStatic (sing :: Sing "org.apache.spark.SparkFiles") "get" [coerce jfilename]
-
-master :: SparkContext -> IO Text
-master sc = do
-  res <- call sc "master" []
-  reify res
-
 getOrCreateSparkContext :: SparkConf -> IO SparkContext
 getOrCreateSparkContext cnf = do
   scalaCtx :: J ('Class "org.apache.spark.SparkContext") <-
     callStatic (sing :: Sing "org.apache.spark.SparkContext") "getOrCreate" [coerce cnf]
 
   callStatic (sing :: Sing "org.apache.spark.api.java.JavaSparkContext") "fromSparkContext" [coerce scalaCtx]
+
+-- | Adds the given file to the pool of files to be downloaded
+--   on every worker node. Use 'getFile' on those nodes to
+--   get the (local) file path of that file in order to read it.
+addFile :: SparkContext -> FilePath -> IO ()
+addFile sc fp = do
+  jfp <- reflect (Text.pack fp)
+  call sc "addFile" [coerce jfp]
+
+-- | Returns the local filepath of the given filename that
+--   was "registered" using 'addFile'.
+getFile :: FilePath -> IO FilePath
+getFile filename = do
+  jfilename <- reflect (Text.pack filename)
+  fmap Text.unpack . reify =<< callStatic (sing :: Sing "org.apache.spark.SparkFiles") "get" [coerce jfilename]
+
+master :: SparkContext -> IO Text
+master sc = do
+  res <- call sc "master" []
+  reify res
+
+-- | See Note [Reading Files] ("Control.Distributed.Spark.RDD#reading_files").
+textFile :: SparkContext -> FilePath -> IO (RDD Text)
+textFile sc path = do
+  jpath <- reflect (Text.pack path)
+  call sc "textFile" [coerce jpath]
+
+-- | The record length must be provided in bytes.
+--
+-- See Note [Reading Files] ("Control.Distributed.Spark.RDD#reading_files").
+binaryRecords :: SparkContext -> FilePath -> Int32 -> IO (RDD ByteString)
+binaryRecords sc fp recordLength = do
+  jpath <- reflect (Text.pack fp)
+  call sc "binaryRecords" [coerce jpath, coerce recordLength]
+
+parallelize
+  :: Reflect a ty
+  => SparkContext
+  -> [a]
+  -> IO (RDD a)
+parallelize sc xs = do
+    jxs :: J ('Iface "java.util.List") <- arrayToList =<< reflect xs
+    call sc "parallelize" [coerce jxs]
+  where
+    arrayToList jxs =
+        callStatic
+          (sing :: Sing "java.util.Arrays")
+          "asList"
+          [coerce (unsafeCast jxs :: JObjectArray)]


### PR DESCRIPTION
These are methods of the Context class, but for some reason were
defined in RDD.hs instead of Context.hs.