### PR TITLE
Switch RDD bindings to using inline-java under the hood.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,15 +1,4 @@
 import Distribution.Simple
-import System.Process
-import System.Exit
+import Language.Java.Inline.Cabal
 
-main = defaultMainWithHooks simpleUserHooks { postBuild = buildJavaSource }
-
-buildJavaSource _ _ _ _ = do
-    executeShellCommand "gradle build"
-    return ()
-
-executeShellCommand cmd = system cmd >>= check
-  where
-    check ExitSuccess = return ()
-    check (ExitFailure n) =
-        error $ "Command " ++ cmd ++ " exited with failure code " ++ show n
+main = defaultMainWithHooks (gradleHooks simpleUserHooks)

--- a/sparkle.cabal
+++ b/sparkle.cabal
@@ -37,7 +37,7 @@ custom-setup
   setup-depends:
     base,
     Cabal >= 1.24,
-    process
+    inline-java >= 0.6.3
 
 library
   include-dirs: cbits
@@ -67,8 +67,9 @@ library
     bytestring >=0.10,
     choice >= 0.1,
     distributed-closure >=0.3,
+    inline-java >= 0.6.3,
     jni >=0.3.0,
-    jvm >=0.2.0,
+    jvm >=0.2.1,
     singletons >= 2.0,
     streaming >= 0.1,
     text >=1.2,

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ packages:
 
 extra-deps:
 - jni-0.3.0
-- jvm-0.2.0
+- jvm-0.2.1
 - jvm-streaming-0.2
 - inline-java-0.6.3
 


### PR DESCRIPTION
Using inline-java slows down the compilation of sparkle, but is safer
because we can thus get the benefit of *both* type checkers (Java and
Haskell). In fact the extra safety isn't just theoretical: this patch
also includes a fix to the binding for `treeAggregate`, which was
supplying arguments in the wrong order.

This is preliminary work ahead of implementing #57, which we can do
serenely from the moment that the type checkers have our back.

This patch only switches over RDD for now. The rest can come later.