### PR TITLE
Support shipping anonymous inline-java objects.

### DIFF
--- a/apps/bench/Main.hs
+++ b/apps/bench/Main.hs
@@ -38,6 +38,8 @@ mapHaskell rdd = reify =<< [java| $rdd.map($hincr).count() |]
 main :: IO ()
 main = do
     conf <- newSparkConf "RDD benchmarks"
+    confSet conf "spark.serializer" "org.apache.spark.serializer.KryoSerializer"
+    confSet conf "spark.kryo.registrator" "io.tweag.sparkle.kryo.InlineJavaRegistrator"
     sc   <- getOrCreateSparkContext conf
     forM_ [0,200..10000 :: Int32] $ \x -> do
       putStrLn $ "Size " ++ show x

--- a/sparkle.cabal
+++ b/sparkle.cabal
@@ -15,6 +15,7 @@ extra-source-files:
   cbits/io_tweag_sparkle_Sparkle.h
   src/main/java/io/tweag/sparkle/Sparkle.java
   src/main/java/io/tweag/sparkle/SparkMain.java
+  src/main/java/io/tweag/sparkle/kryo/InlineJavaRegistrator.java
   src/main/java/io/tweag/sparkle/function/HaskellVoidFunction.java
   src/main/java/io/tweag/sparkle/function/HaskellFunction4.java
   src/main/java/io/tweag/sparkle/function/HaskellFunction0.java

--- a/src/Control/Distributed/Spark.hs
+++ b/src/Control/Distributed/Spark.hs
@@ -14,3 +14,16 @@ import Control.Distributed.Spark.SQL.DataFrame as S hiding
   (distinct, filter, join, schema)
 import Control.Distributed.Spark.SQL.Row as S
 import Control.Distributed.Spark.RDD as S
+import Foreign.JNI.Types (JNIEnv, JClass)
+import Foreign.Ptr (Ptr)
+import Language.Java.Inline
+
+foreign export ccall
+  "Java_io_tweag_sparkle_Sparkle_loadJavaWrappers"
+  jniLoadJavaWrappers
+  :: Ptr JNIEnv
+  -> Ptr JClass
+  -> IO ()
+
+jniLoadJavaWrappers :: Ptr JNIEnv -> Ptr JClass -> IO ()
+jniLoadJavaWrappers _ _ = loadJavaWrappers

--- a/src/main/java/io/tweag/sparkle/Sparkle.java
+++ b/src/main/java/io/tweag/sparkle/Sparkle.java
@@ -11,4 +11,5 @@ public class Sparkle extends SparkleBase {
 
     public static native <R> R apply(byte[] cos, Object... args);
     private static native void initializeHaskellRTS();
+    public static native void loadJavaWrappers();
 }

--- a/src/main/java/io/tweag/sparkle/kryo/InlineJavaRegistrator.java
+++ b/src/main/java/io/tweag/sparkle/kryo/InlineJavaRegistrator.java
@@ -1,0 +1,18 @@
+package io.tweag.sparkle;
+
+import com.esotericsoftware.kryo.Kryo;
+import org.apache.spark.serializer.KryoRegistrator;
+
+/**
+ * Register inline-java classes for Kryo serialization. Unlike other
+ * registrators, calling this class is not just necessary for good
+ * performance, it is necessary for correctness. Deserialization of
+ * anonymous classes in inline-java quotes will fail without it.
+ */
+public class InlineJavaRegistrator implements KryoRegistrator {
+    public void registerClasses(Kryo kryo) {
+	Sparkle.loadJavaWrappers();
+	// TODO actually register classes to make their encoding more
+	// space efficient.
+    }
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@ extra-deps:
 - jni-0.3.0
 - jvm-0.2.1
 - jvm-streaming-0.2
-- inline-java-0.6.3
+- inline-java-0.6.5
 
 nix:
   # Requires Stack >= 1.2.


### PR DESCRIPTION
Just like in straight Java, it's perfectly legal in an inline-java
quasiquote to create an object of anonymous class. The problem is,
such an object can't be deserialized from any process that hasn't yet
loaded the wappers for all quasiquotes, since it is the wrappers that
"define" the anonymous class.

Spark executors can be given a task by the Spark driver that includes
such anonymous objects. Without the InlineJavaRegistrator provided
here, it is not possible to guarantee that the inline-java wrappers
have been loaded *prior* to the task being deserialized.

The solution here consists in choosing the Kryo serializer. It's
much faster than the default `JavaSerializer` that Spark uses anyways.
`KryoSerializer` provides a crucial facility that `JavaSerializer`
does not: class registration. Spark furthermore defines "registrator"
classes that when invoked perform class registration, or indeed any
arbitrary action. We provide an `InlineJavaRegistrator` to inline-java
users, which abuses class registration to first load all wrappers.
This happens on all executors prior to any work being performed.

Fixes #104.