### PR TITLE
Fix the nixpkgs pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM tweag/stack-docker-nix
 MAINTAINER Mathieu Boespflug <m@tweag.io>
 
 ADD shell.nix /
+ADD nixpkgs.nix /
 # Clean up non-essential downloaded archives after provisioning a shell.
 RUN nix-shell /shell.nix --indirect --add-root /nix-shell-gc-root \
     && nix-collect-garbage

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,1 @@
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/e91840cfb6b7778f8c29d455a2f24cffa1b4e43e.tar.gz")

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
-{ nixpkgs ? import <nixpkgs> {}
+{ nixpkgs ?  import ./nixpkgs.nix {}
 , ghc ? nixpkgs.haskell.compiler.ghc802 # Default needed for Docker build.
 }:
 
-with import (fetchTarball https://github.com/nixos/nixpkgs/archive/e91840cfb6b7778f8c29d455a2f24cffa1b4e43e.tar.gz) {};
+with nixpkgs;
 
 let
   spark = nixpkgs.spark.override { mesosSupport = false; };

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ packages:
 nix:
   # Requires Stack >= 1.2.
   shell-file: shell.nix
+  path: ["nixpkgs=./nixpkgs.nix"]
 
 docker:
   enable: false


### PR DESCRIPTION
- Remove leftover references to `<nixpkgs>` in the shell file (in
  particular the `ghc` used came from the outside `<nixpkgs>` instead of
  the pinned revision, which could lead to weird things)

- Force `stack --nix` to use the `ghc` from the pinned `nixpkgs`