### PR TITLE
Use StaticPointers for PairRDD

### DIFF
--- a/src/Control/Distributed/Spark/PairRDD.hs
+++ b/src/Control/Distributed/Spark/PairRDD.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}


### PR DESCRIPTION
As discussed, fixes #119

This is caused by https://ghc.haskell.org/trac/ghc/ticket/14204 + withStatic TH macro used to create instances in PairRDD module. The bug results in `static` being allowed to be used with Tuple2 constructor without a compile-time error, which instead leads to a run-time one. For example,

    swapPair :: Tuple2 a b -> Tuple2 b a
    swapPair (Tuple2 a b) = Tuple2 b a

    mapSwap :: ( Static (Reify a), Static (Reify b)
               , Static (Reflect a), Static (Reflect b)
               , Typeable a, Typeable b)
            => PairRDD a b
            -> IO (PairRDD b a)
    mapSwap rdd =
      PairRDD.fromRDD =<<
      RDD.map (closure (static swapPair)) =<<
      PairRDD.toRDD rdd
   
fails with

    sparkle-worker: GHC bug - makeStatic: Unresolved static form at line 107, column 1.
    CallStack (from HasCallStack):
      error, called at libraries/base/GHC/StaticPtr/Internal.hs:26:5 in base:GHC.StaticPtr.Internal