### PR TITLE
Preliminary bazel support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 .stack-work
 .gradle
 build
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,81 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+  "haskell_library",
+  "haskell_toolchain",
+  "haskell_cc_import",
+)
+
+load(":sparkle.bzl", "wrap_sparkle_hs")
+
+_sparkle_java_deps = [
+  "@org_apache_spark_spark_core_2_10//jar",
+  "@org_apache_spark_spark_mllib_2_10//jar",
+  "@com_esotericsoftware_kryo//jar",
+]
+
+java_binary(
+  name = "sparkle-jar",
+  deps = _sparkle_java_deps,
+  srcs = glob(["src/main/java/io/tweag/sparkle/**/*.java"]),
+  main_class = "io.tweag.sparkle.SparkMain",
+)
+
+haskell_library(
+  name = "sparkle-lib",
+  src_strip_prefix = "src",
+  srcs = glob(['src/**/*.hs']),
+  deps = [
+    "@io_tweag_inline_java//jni",
+    "@io_tweag_inline_java//jvm",
+    "@io_tweag_inline_java//jvm-streaming",
+    "@io_tweag_inline_java//:inline-java",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "binary",
+    "bytestring",
+    "choice",
+    "distributed-closure",
+    "singletons",
+    "streaming",
+    "text",
+    "vector",
+  ],
+  data = [
+    "@org_scala_lang_scala_library//jar",
+  ] + _sparkle_java_deps,
+)
+
+haskell_binary(
+  name = "sparkle-hs",
+  srcs = ["Sparkle_run.hs"],
+  main = "Sparkle_run.main",
+  deps = [
+    ":sparkle-lib",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "filepath",
+    "process",
+    "regex-tdfa",
+    "text",
+    "zip-archive",
+  ],
+  compiler_flags = ["-threaded"],
+)
+
+wrap_sparkle_hs(
+  name = "sparkle",
+  sparkle_hs_rule = ":sparkle-hs",
+  sparkle_jar_rule = ":sparkle-jar",
+)
+
+haskell_toolchain(
+  name = "sparkle-toolchain",
+  version = "8.2.2",
+  tools = "@sparkle-toolchain//:bin",
+)

--- a/Sparkle.hs
+++ b/Sparkle.hs
@@ -1,46 +1,16 @@
-module Main where
+{-# LANGUAGE LambdaCase #-}
+module Sparkle (main) where
 
-import Codec.Archive.Zip
-import Data.Text (pack, strip, unpack)
-import Data.List (isInfixOf)
-import qualified Data.ByteString.Lazy as BS
 import Paths_sparkle
+import Sparkle_run (doPackage)
 import System.Environment (getArgs)
-import System.FilePath ((</>), (<.>), takeBaseName, takeFileName)
-import System.Info (os)
-import System.IO (hPutStrLn, stderr)
-import System.Process (readProcess)
-import Text.Regex.TDFA
+import System.FilePath ((</>))
 
-doPackage :: FilePath -> IO ()
-doPackage cmd = do
-    dir <- getDataDir
-    jarbytes <- BS.readFile (dir </> "sparkle.jar")
-    cmdpath <- unpack . strip . pack <$> readProcess "which" [cmd] ""
-    ldd <- case os of
-      "darwin" -> do
-        hPutStrLn
-          stderr
-          "WARNING: JAR not self contained on OS X (shared libraries not copied)."
-        return ""
-      _ -> readProcess "ldd" [cmdpath] ""
-    let libs =
-          filter (\x -> not $ any (`isInfixOf` x) ["libc.so", "libpthread.so"]) $
-          map (!! 1) (ldd =~ " => ([[:graph:]]+) " :: [[String]])
-    libentries <- mapM mkEntry libs
-    cmdentry <- toEntry "hsapp" 0 <$> BS.readFile cmdpath
-    let appzip =
-          toEntry "sparkle-app.zip" 0 $
-          fromArchive $
-          foldr addEntryToArchive emptyArchive (cmdentry : libentries)
-        newjarbytes = fromArchive $ addEntryToArchive appzip (toArchive jarbytes)
-    BS.writeFile ("." </> takeBaseName cmd <.> "jar") newjarbytes
-  where
-    mkEntry file = toEntry (takeFileName file) 0 <$> BS.readFile file
-
+-- | If you would like to specify path to the sparkle JAR instead of
+-- letting cabal look it up, please use @Sparkle_run.hs@ instead.
 main :: IO ()
-main = do
-    argv <- getArgs
-    case argv of
-      ["package", cmd] -> doPackage cmd
-      _ -> fail "Usage: sparkle package <command>"
+main = getArgs >>= \case
+  ["package", cmd] -> do
+    jarPath <- (</> "sparkle.jar") <$> getDataDir
+    doPackage jarPath cmd
+   _ -> fail "Usage: sparkle package <command>"

--- a/Sparkle_run.hs
+++ b/Sparkle_run.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE LambdaCase #-}
+module Sparkle_run (main, doPackage) where
+
+import Codec.Archive.Zip
+import Data.Text (pack, strip, unpack)
+import Data.List (isInfixOf)
+import qualified Data.ByteString.Lazy as BS
+import System.Environment (getArgs)
+import System.FilePath ((</>), (<.>), takeBaseName, takeFileName)
+import System.Info (os)
+import System.IO (hPutStrLn, stderr)
+import System.Process (readProcess)
+import Text.Regex.TDFA
+
+doPackage :: FilePath -- ^ Path to sparkle jar
+          -> FilePath -- ^ Command to run
+          -> IO ()
+doPackage sparklePath cmd = do
+    jarbytes <- BS.readFile sparklePath
+    cmdpath <- unpack . strip . pack <$> readProcess "which" [cmd] ""
+    ldd <- case os of
+      "darwin" -> do
+        hPutStrLn
+          stderr
+          "WARNING: JAR not self contained on OS X (shared libraries not copied)."
+        return ""
+      _ -> readProcess "ldd" [cmdpath] ""
+    let libs =
+          filter (\x -> not $ any (`isInfixOf` x) ["libc.so", "libpthread.so"]) $
+          map (!! 1) (ldd =~ " => ([[:graph:]]+) " :: [[String]])
+    libentries <- mapM mkEntry libs
+    cmdentry <- toEntry "hsapp" 0 <$> BS.readFile cmdpath
+    let appzip =
+          toEntry "sparkle-app.zip" 0 $
+          fromArchive $
+          foldr addEntryToArchive emptyArchive (cmdentry : libentries)
+        newjarbytes = fromArchive $ addEntryToArchive appzip (toArchive jarbytes)
+    BS.writeFile ("." </> takeBaseName cmd <.> "jar") newjarbytes
+  where
+    mkEntry file = toEntry (takeFileName file) 0 <$> BS.readFile file
+
+-- | This is a main entry point that does not use @Paths_@ to
+-- determine the path of the sparkle jar. If you would like that, you
+-- should be compiling and using @Sparkle.hs@ instead which is the
+-- cabal default.
+main :: IO ()
+main = getArgs >>= \case
+  ["--sparkle-jar", jar, "package", cmd] -> doPackage jar cmd
+  _ -> fail "Usage: sparkle --sparkle-jar JARPATH package <command>"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,146 @@
+workspace(name = "io_tweag_sparkle")
+
+http_archive(
+  name = "io_tweag_rules_haskell",
+  strip_prefix = "rules_haskell-46313a8a76ec0e5666c572d921418ce14988aaa4",
+  urls = ["https://github.com/tweag/rules_haskell/archive/46313a8a76ec0e5666c572d921418ce14988aaa4.tar.gz"]
+)
+
+local_repository(
+  name = "io_tweag_rules_haskell",
+  path = "/home/shana/programming/rules_haskell",
+)
+
+http_archive(
+  name = "io_tweag_rules_nixpkgs",
+  strip_prefix = "rules_nixpkgs-53700e429928530f1566cfff3ec00283a123f17f",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/53700e429928530f1566cfff3ec00283a123f17f.tar.gz"],
+)
+
+# Required due to rules_haskell use of skylib.
+http_archive(
+  name = "bazel_skylib",
+  strip_prefix = "bazel-skylib-0.2.0",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.2.0.tar.gz"]
+)
+
+http_archive(
+  name = "io_tweag_inline_java",
+  strip_prefix = "inline-java-50bbcc2c4d833b261aaacb7b5033123e8f0c6373",
+  urls = ["https://github.com/tweag/inline-java/archive/50bbcc2c4d833b261aaacb7b5033123e8f0c6373.tar.gz"],
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
+  "nixpkgs_git_repository",
+  "nixpkgs_package",
+)
+
+nixpkgs_git_repository(
+  name = "nixpkgs",
+  # Keep consistent with ./nixpkgs.nix.
+  revision = "4026ea9c8afd09b60896b861a04cc5748fdcdfb4",
+)
+
+maven_jar(
+  name = "org_apache_spark_spark_core_2_10",
+  artifact = "org.apache.spark:spark-core_2.10:1.6.0",
+)
+
+maven_jar(
+  name = "org_apache_spark_spark_mllib_2_10",
+  artifact = "org.apache.spark:spark-mllib_2.10:1.6.0",
+)
+
+maven_jar(
+  name = "com_esotericsoftware_kryo",
+  artifact = "com.esotericsoftware:kryo:4.0.1",
+)
+
+maven_jar(
+  name = "org_scala_lang_scala_library",
+  artifact = "org.scala-lang:scala-library:2.10.5",
+)
+
+nixpkgs_package(
+  name = "sparkle-toolchain",
+  repository = "@nixpkgs",
+  # This is a hack abusing the fact that CLASSPATH can point at things
+  # that don't exist. We pass these jars Haskell part of sparkle as
+  # extra dependencies and they are available just in time for that
+  # rule. This lets javac be called with the CLASSPATH set. It's not
+  # very nice for obvious reasons of hard-coding things.
+  nix_file_content = """
+let pkgs = import <nixpkgs> {};
+    javac_wrapped = pkgs.stdenv.mkDerivation {
+      name = "javac_wrapped";
+      buildInputs = [ pkgs.openjdk pkgs.makeWrapper ];
+      phases = [ "installPhase" ];
+      installPhase = ''
+        mkdir -p $out/bin
+        makeWrapper ${pkgs.openjdk}/bin/javac $out/bin/javac \
+          --prefix CLASSPATH : "external/org_apache_spark_spark_core_2_10/jar/spark-core_2.10-1.6.0.jar" \
+          --prefix CLASSPATH : "external/org_apache_spark_spark_mllib_2_10/jar/spark-m##llib_2.10-1.6.0.jar" \
+          --prefix CLASSPATH : "external/com_esotericsoftware_kryo/jar/kryo-4.0.1.jar" \
+          --prefix CLASSPATH : "external/org_scala_lang_scala_library/jar/scala-library-2.10.5.jar"
+      '';
+    };
+in pkgs.buildEnv {
+  name = "sparkle-toolchain";
+  paths = with pkgs; [
+    (haskell.packages.ghc822.ghcWithPackages (p: with p; [
+      Cabal
+      base
+      binary
+      bytestring
+      choice
+      constraints
+      containers
+      deepseq
+      directory
+      distributed-closure
+      exceptions
+      filemanip
+      filepath
+      ghc
+      hspec
+      inline-c
+      language-java
+      mtl
+      process
+      regex-tdfa
+      singletons
+      streaming
+      template-haskell
+      temporary
+      text
+      vector
+      zip-archive
+    ]))
+    javac_wrapped
+  ];
+}
+"""
+)
+
+nixpkgs_package(
+  name = "openjdk",
+  repository = "@nixpkgs",
+  build_file_content = """
+filegroup (
+  name = "lib",
+  srcs = ["nix/lib/openjdk/jre/lib/amd64/server/libjvm.so"],
+  visibility = ["//visibility:public"],
+)
+filegroup (
+  name = "jni_header",
+  srcs = ["nix/include/jni.h"],
+  visibility = ["//visibility:public"],
+)
+filegroup (
+  name = "jni_md_header",
+  srcs = ["nix/include/jni_md.h"],
+  visibility = ["//visibility:public"],
+)"""
+)
+
+register_toolchains("//:sparkle-toolchain")

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/1354099daf98b7a1f79e6c41ce6bfda5c40177ae.tar.gz")
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/4026ea9c8afd09b60896b861a04cc5748fdcdfb4.tar.gz")

--- a/sparkle.bzl
+++ b/sparkle.bzl
@@ -1,0 +1,53 @@
+"""Helpers for sparkle packaging."""
+
+def _get_file_from_target(ctx, trgt, fname):
+  for f in trgt.files:
+    if f.basename == fname:
+      return f
+  fail("Could not find {0} in outputs of {1}".format(fname, trgt.label.name))
+
+def _wrap_sparkle_impl(ctx):
+  sparkle_jar = _get_file_from_target(
+    ctx,
+    ctx.attr.sparkle_jar_rule,
+    "{0}.jar".format(ctx.attr.sparkle_jar_rule.label.name),
+  )
+  sparkle_hs = _get_file_from_target(
+    ctx,
+    ctx.attr.sparkle_hs_rule,
+    ctx.attr.sparkle_hs_rule.label.name,
+  )
+  ctx.actions.write(
+    output=ctx.outputs.executable,
+    content=" ".join([
+      sparkle_hs.path,
+      "--sparkle-jar",
+      sparkle_jar.path,
+      '"$@"',
+    ]),
+    is_executable=True,
+  )
+
+  return [DefaultInfo(
+    runfiles=ctx.runfiles(files=[sparkle_hs, sparkle_jar])
+  )]
+
+# Apply --sparkle-jar for the user ensuring that it's available in
+# environment. I don't know if it does anything though because bazel
+# run still doesn't like it
+#
+# https://github.com/bazelbuild/examples/blob/master/rules/runfiles/execute.bzl
+wrap_sparkle_hs = rule(
+  _wrap_sparkle_impl,
+  executable = True,
+  attrs = {
+    "sparkle_hs_rule": attr.label(
+      mandatory=True,
+      doc="Haskell sparkle binary rule.",
+    ),
+    "sparkle_jar_rule": attr.label(
+      mandatory=True,
+      doc="Sparkle Java rule.",
+    ),
+  },
+)

--- a/sparkle.cabal
+++ b/sparkle.cabal
@@ -84,6 +84,7 @@ library
 executable sparkle
   main-is: Sparkle.hs
   other-modules: Paths_sparkle
+                 Sparkle_run
   build-depends:
     base >= 4.8 && < 5,
     bytestring >= 0.10,


### PR DESCRIPTION
For the most part this should be self-explanatory but there are a
couple of things that need to be talked about and resolved in the
future one way or another, be it in sparkle/inline-java or
rules_haskell.

* `inline-java` relies on `javac`. We can provide this trivially
  through nix. In practice however that's quite useless: in sparkle we
  want `javac` with Java part of `sparkle` in the CLASSPATH. This is
  because we want to compile Java bytecode during GHC compilation that
  depends on it. The existing cabal way is to run `gradle` build
  before GHC runs, extract and set CLASSPATH that way. With bazel we
  do not have the luxury of Cabal's setup hooks. This is an awful way
  to begin with: running another build system during Haskell
  compilation just seems wrong but the problem remains.
 * We want to build Java part of sparkle with `bazel`: after all
  that's the big part of the appeal: `bazel` has rules for multiple
  languages so we should be able to use them. This means that ideally
  we do not want to just say "OK, let's just use nix to compile the
  Java part: it has the authoritative access to the jars and we can
  easily refer to them by absolute path by wrapping javac". While this
  could work, it gives too much to do for nix.
* Even if we were to be able to extract CLASSPATH from sparkle's
  Java (this is somewhat doable with a custom rule), we still have no
  way of feeding this into `rules_haskell`: we don't want to
  have to have specific Java handling in Haskell rules. It's an
  implementation detail of inline-java that it's done this way and
  it'd be wrong to put in code to accommodate this library.
* It seems like we should just provide the javac with the right
  CLASSPATH already available, somewhat like what we do with GHC.
* All of the above give rise to the hack of providing a toolchain with
  `javac` that has a CLASSPATH already set. Then when it comes time to
  actually use it, we make sure that the jars are in place through
  `rule_haskell`s `data` section.
* This is fragile and ungraceful, polluting the build env with a
  CLASSPATH. It works for this usecase but ideally we don't want it to
  exist.
* Another thing to discuss is `Sparkle.hs`. Currently it relies on
  `Paths_` to find sparkle jar which is a Cabal feature. I have put in
  a workaround where cabal users can keep relying on it but others can
  use a different `main` which requires that this is passed in.
* Trying to increase UX for the above build target, I have writted a
  small wrapper around the binary which fills in this flag
  for the user with location of the jar produced earlier on in the
  build. This way user does not manually fiddle with paths.
* This works if we `bazel build` and `./bazel-bin/sparkle` but doesn't
  work if we try to `bazel run`. I could not figure out how to get the
  latter working.

w.r.t. `javac`: the problem in general is that we want to define a
toolchain from a rule that's using the toolchain. I think the best
way to solve this would be to use two toolchains:

* toolchain_1 builds sparkle JARs; this toolchain has javac only
* toolchain_2 is created depending on sparkle java target: this
  toolchain has GHC + javac + CLASSPATH.
* toolchain_2 is used for compiling everything else.

We could have a third toolchain which is just GHC only but it adds a
chance that we mix GHC being used &c. (which may be OK).

I am unsure if this approach is doable, I have not explored it yet. It
would likely require defining some sparkle_toolchain with appropriate
rules_haskell toolchain type.

----

There was also talk about inline-java instead outputting Java files
that we could then compile. In theory this would be the nicest way for
us as long as we know what it outputs. I don't see however how it
would work in practice: as far as I understand, the Haskell
compilation relies on the bytecode being produced during compilation
and it's used for things (type inferrence?). Further our existing
Haskell rules can't accommodate such a stop-start approach: they
always expect that a library is produced in the end. We would need
some custom rule that only spits out the generated Java files, we'd
have to compile those then we still have to figure out how to supply
it back to GHC for the rest of the compilation.