### PR TITLE
Drop ghc-8.10 support and update nixpkgs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,11 +2,11 @@ build --host_javabase=@local_jdk//:jdk
 build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 
-build:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
-build:ghc_9_0_1 --build_tag_filters -skip_with_ghc_9_0_1
-build:ghc_9_0_1 --test_tag_filters -skip_with_ghc_9_0_1
-fetch:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
-query:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
-sync:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
+#build:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
+#build:ghc_9_0_1 --build_tag_filters -skip_with_ghc_9_0_1
+#build:ghc_9_0_1 --test_tag_filters -skip_with_ghc_9_0_1
+#fetch:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
+#query:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
+#sync:ghc_9_0_1 --repo_env=GHC_VERSION=9.0.1
 
 try-import .bazelrc.local

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,9 +18,3 @@ steps:
       - nix-shell --pure --run "bazel run spark-submit -- --packages com.amazonaws:aws-java-sdk:1.11.920,org.apache.hadoop:hadoop-aws:2.8.4 $(pwd)/bazel-bin/apps/lda/sparkle-example-lda_deploy.jar"
       - spark-submit bazel-bin/apps/osthreads/sparkle-example-osthreads_deploy.jar | tee out.txt || grep "Job |           pool | start time (s) | end time (s)" out.txt
     timeout: 60
-  - label: "Build and test with bazel and ghc-9.0.1"
-    command:
-      - echo "build --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs" > .bazelrc.local
-      - nix-shell --pure --run 'bazel build //apps/hello:sparkle-example-hello_deploy.jar --config ghc_9_0_1' shell-linear-types.nix
-      - nix-shell --pure --run 'bazel run spark-submit -- --packages com.amazonaws:aws-java-sdk:1.11.920,org.apache.hadoop:hadoop-aws:2.8.4 $(pwd)/bazel-bin/apps/hello/sparkle-example-hello_deploy.jar --config ghc_9_0_1' shell-linear-types.nix
-    timeout: 60

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
       - run:
           name: Install Nix
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install xz
             curl -L https://nixos.org/nix/install | sh
 
       - run:
@@ -74,20 +73,21 @@ jobs:
             nix-shell --pure --run "bazel build //apps/hello:sparkle-example-hello_deploy.jar $BAZEL_ARGS"
             nix-shell --pure --run "bazel build //apps/rdd-ops:sparkle-example-rddops_deploy.jar $BAZEL_ARGS"
             nix-shell --pure --run "bazel build //apps/osthreads:sparkle-example-osthreads_deploy.jar $BAZEL_ARGS"
+
       - run:
           name: Install spark and hadoop
           command: |
             # We roll our own installation of spark in OSX since nixpkgs doesn't support building hadoop
-            curl -O https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar
-            curl https://downloads.apache.org/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz | tar -xz
-            curl https://downloads.apache.org/spark/spark-2.4.7/spark-2.4.7-bin-without-hadoop.tgz | tar -xz
+            curl -OL https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar
+            curl -L https://downloads.apache.org/spark/spark-2.4.8/spark-2.4.8-bin-without-hadoop.tgz | tar -xz
+            curl -L https://downloads.apache.org/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz | tar -xz
 
       - run:
           name: Run tests
           shell: /bin/bash -eilo pipefail
           command: |
             export SPARK_DIST_CLASSPATH=$PWD/slf4j-api-1.7.30.jar:$(hadoop-2.10.1/bin/hadoop classpath)
-            export PATH="$PWD/spark-2.4.7-bin-without-hadoop/bin:$PATH"
+            export PATH="$PWD/spark-2.4.8-bin-without-hadoop/bin:$PATH"
             spark-submit --packages com.amazonaws:aws-java-sdk:1.11.920,org.apache.hadoop:hadoop-aws:2.8.4 bazel-bin/apps/hello/sparkle-example-hello_deploy.jar
 
         # see note about 'Disk cache'

--- a/BUILD
+++ b/BUILD
@@ -1,10 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["hs-wrapper/FFIWrapper.hs"])
+
 load(
   "@rules_haskell//haskell:defs.bzl",
   "haskell_binary",
   "haskell_library",
-  "haskell_toolchain",
+  "haskell_toolchain_library",
 )
 
 _sparkle_java_deps = [
@@ -29,6 +31,11 @@ cc_library(
   copts = ["-std=c99"],
 ) 
 
+haskell_toolchain_library(
+    name = "base",
+    package = "base",
+)
+
 haskell_library(
   name = "sparkle-lib",
   src_strip_prefix = "src",
@@ -48,7 +55,7 @@ haskell_library(
     "@maven//:org_scala_lang_scala_reflect",
     ":sparkle-jar",
     ":sparkle-bootstrap-cc",
-	"@stackage//:base",
+	":base",
 	"@stackage//:binary",
 	"@stackage//:bytestring",
 	"@stackage//:choice",

--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,6 @@ load(
   "haskell_library",
   "haskell_toolchain",
 )
-load("@config_settings//:info.bzl", "ghc_version")
 
 _sparkle_java_deps = [
   "@maven//:org_apache_spark_spark_core_2_11",
@@ -55,11 +54,11 @@ haskell_library(
 	"@stackage//:choice",
 	"@stackage//:constraints",
 	"@stackage//:distributed-closure",
+	"@stackage//:singletons",
 	"@stackage//:streaming",
 	"@stackage//:text",
 	"@stackage//:vector",
-  ] + _sparkle_java_deps +
-  ([] if ghc_version == "9.0.1" else ["@stackage//:singletons"]),
+  ] + _sparkle_java_deps,
   plugins = ["@io_tweag_inline_java//:inline-java-plugin"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,6 @@ exports_files(["hs-wrapper/FFIWrapper.hs"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
   "haskell_library",
   "haskell_toolchain_library",
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-* Support for ghc-8.10.2
-
 ### Changed
 
 * Fixed sparkle packaging in some ubuntus. (#149)
+
+### Removed
+
+* Support for ghc-8.10
 
 ## [0.7.4] - 2018-02-28
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ $ nix-shell --pure --run "bazel build //apps/hello:sparkle-example-hello_deploy.
 $ nix-shell --pure --run "bazel run spark-submit -- --packages com.amazonaws:aws-java-sdk:1.11.920,org.apache.hadoop:hadoop-aws:2.8.4 $PWD/bazel-bin/apps/hello/sparkle-example-hello_deploy.jar"
 ```
 
-You'll need [nix] for the above to work.
-
-[bazel]: https://bazel.build
+You'll need [Nix][nix] for the above to work.
 
 ## How it works
 
@@ -55,15 +53,15 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
-load("@//:sparkle.bzl", "sparkle_package")
+load("@io_tweag_sparkle//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+# hello-hs needs to contain a Main module with a main function.
+# This main function will be invoked by spark.
+haskell_library (
   name = "hello-hs",
-  linkstatic = False,
-  compiler_flags = ["-threaded", "-pie"],
   srcs = ...,
   deps = ...,
   ...
@@ -73,6 +71,14 @@ sparkle_package(
   name = "sparkle-example-hello",
   src = ":hello-hs",
 )
+```
+
+You might want to add the following settings to your `.bazelrc.local`
+file.
+```
+common --repository_cache=~/.bazel_repo_cache
+common --disk_cache=~/.bazel_disk_cache
+common --local_cpu_resources=4
 ```
 
 And then ask [Bazel][bazel] to build a *deploy* jar file.
@@ -141,10 +147,8 @@ a [whole cluster from scratch on EC2][spark-ec2]. This
 the [Databricks hosted platform][databricks] and on
 [Amazon's Elastic MapReduce][aws-emr].
 
+[bazel]: https://bazel.build
 [docker-build-img]: https://hub.docker.com/r/tweag/sparkle/
-[stack]: https://github.com/commercialhaskell/stack
-[stack-docker]: https://docs.haskellstack.org/en/stable/docker_integration/
-[stack-nix]: https://docs.haskellstack.org/en/stable/nix_integration/#configuration
 [spark-submit]: http://spark.apache.org/docs/1.6.2/submitting-applications.html
 [spark-ec2]: http://spark.apache.org/docs/1.6.2/ec2-scripts.html
 [nix]: http://nixos.org/nix

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,9 +18,9 @@ http_archive(
 
 http_archive(
   name = "io_tweag_inline_java",
-  sha256 = "52f61aa7069343667fba6f428fca5768d74b1240cefeb9620ba12c0779f21afc",
-  strip_prefix = "inline-java-a466217e2d382702b1809162ee0bad2ae4812dc0",
-  urls = ["https://github.com/tweag/inline-java/archive/a466217e2d382702b1809162ee0bad2ae4812dc0.tar.gz"],
+  sha256 = "b989a1c3fe56f2f3bd668ce9440bdcc371e3d7e41ea057ac35f38e518fc6de53",
+  strip_prefix = "inline-java-dafa0a8e670b56b6ad015fb864aa9be62e13e64c",
+  urls = ["https://github.com/tweag/inline-java/archive/dafa0a8e670b56b6ad015fb864aa9be62e13e64c.tar.gz"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "haskell_repositories")
@@ -89,15 +89,15 @@ filegroup (
 """
 )
 
-nixpkgs_package(
-    name = "stack_ignore_global_hints",
-    attribute_path = "stack_ignore_global_hints",
-    repository = "@nixpkgs",
-)
+#nixpkgs_package(
+#    name = "stack_ignore_global_hints",
+#    attribute_path = "stack_ignore_global_hints",
+#    repository = "@nixpkgs",
+#)
 
-load("//:config_settings/setup.bzl", "config_settings")
-config_settings(name = "config_settings")
-load("@config_settings//:info.bzl", "ghc_version")
+#load("//:config_settings/setup.bzl", "config_settings")
+#config_settings(name = "config_settings")
+#load("@config_settings//:info.bzl", "ghc_version")
 
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
@@ -124,10 +124,12 @@ stack_snapshot(
         "hspec",
         "inline-c",
         "language-java",
+        "linear-base",
         "mtl",
         "process",
         "regex-tdfa",
         "singletons",
+        "singletons-base",
         "stm",
         "streaming",
         "template-haskell",
@@ -135,9 +137,8 @@ stack_snapshot(
         "text",
         "vector",
         "zip-archive",
-    ] + (["linear-base"] if ghc_version == "9.0.1" else ["singletons"]),
-    snapshot = "nightly-2020-11-11" if ghc_version == "8.10.2" else None,
-    local_snapshot = "//:snapshot-9.0.1.yaml" if ghc_version == "9.0.1" else None,
+    ],
+    local_snapshot = "//:snapshot-9.0.1.yaml",
 #   stack = "@stack_ignore_global_hints//:bin/stack" if ghc_version == "9.0.1" else None,
 )
 
@@ -158,11 +159,10 @@ filegroup(
 )
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc901"
-        if ghc_version == "9.0.1" else "haskell.compiler.ghc8102",
+    attribute_path = "haskell.compiler.ghc901",
     locale_archive = "@glibc_locales//:locale-archive",
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = ghc_version if ghc_version == "8.10.2" else "9.0.1",
+    version = "9.0.1",
     compiler_flags = [
         "-Werror",
         "-Wall",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,9 @@ http_archive(
 
 http_archive(
   name = "io_tweag_clodl",
-  sha256 = "dd3729c49c169fa632ced79e5680e60a072b3204a8044daac4f51832ddae74a3",
-  strip_prefix = "clodl-4143916be74a0d048fea5aaca465c6581313a2f8",
-  urls = ["https://github.com/tweag/clodl/archive/4143916be74a0d048fea5aaca465c6581313a2f8.tar.gz"]
+  sha256 = "3756e581eb0344da85578667298d39d111b215b3e67ec99c36f612e15ecd5f6d",
+  strip_prefix = "clodl-8d5b05727915b2ab0e7dfcee91a2c81a0d7edf7b",
+  urls = ["https://github.com/tweag/clodl/archive/8d5b05727915b2ab0e7dfcee91a2c81a0d7edf7b.tar.gz"]
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,6 +127,7 @@ stack_snapshot(
         "mtl",
         "process",
         "regex-tdfa",
+        "singletons",
         "stm",
         "streaming",
         "template-haskell",
@@ -137,7 +138,7 @@ stack_snapshot(
     ] + (["linear-base"] if ghc_version == "9.0.1" else ["singletons"]),
     snapshot = "nightly-2020-11-11" if ghc_version == "8.10.2" else None,
     local_snapshot = "//:snapshot-9.0.1.yaml" if ghc_version == "9.0.1" else None,
-    stack = "@stack_ignore_global_hints//:bin/stack" if ghc_version == "9.0.1" else None,
+#   stack = "@stack_ignore_global_hints//:bin/stack" if ghc_version == "9.0.1" else None,
 )
 
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
@@ -161,7 +162,7 @@ haskell_register_ghc_nixpkgs(
         if ghc_version == "9.0.1" else "haskell.compiler.ghc8102",
     locale_archive = "@glibc_locales//:locale-archive",
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = ghc_version if ghc_version == "8.10.2" else "9.0.0.20201227",
+    version = ghc_version if ghc_version == "8.10.2" else "9.0.1",
     compiler_flags = [
         "-Werror",
         "-Wall",

--- a/apps/argv/BUILD.bazel
+++ b/apps/argv/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "argv-hs",
-  linkstatic = False,
   srcs = ["Argv.hs"],
   deps = [
     "//:sparkle-lib",
@@ -18,7 +17,6 @@ haskell_binary(
 	"@stackage//:text",
 	"@stackage//:vector",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/bench/BUILD.bazel
+++ b/apps/bench/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "bench-hs",
-  linkstatic = False,
   srcs = ["Main.hs"],
   plugins = ["@io_tweag_inline_java//:inline-java-plugin"],
   deps = [
@@ -25,7 +24,6 @@ haskell_binary(
 	"@stackage//:text",
 	"@stackage//:vector",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/dataframe/BUILD.bazel
+++ b/apps/dataframe/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "dataframe",
-  linkstatic = False,
   srcs = ["Main.hs"],
   deps = [
     "//:sparkle-lib",
@@ -18,7 +17,6 @@ haskell_binary(
 	"@stackage//:distributed-closure",
 	"@stackage//:text",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/hello/BUILD.bazel
+++ b/apps/hello/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "hello-hs",
-  linkstatic = False,
   srcs = ["HelloSpark.hs"],
   deps = [
     "//:sparkle-lib",
@@ -17,7 +16,6 @@ haskell_binary(
 	"@stackage//:distributed-closure",
 	"@stackage//:text",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/lda/BUILD.bazel
+++ b/apps/lda/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "lda-hs",
-  linkstatic = False,
   srcs = ["SparkLDA.hs"],
   deps = [
     "//:sparkle-lib",
@@ -17,7 +16,6 @@ haskell_binary(
 	"@stackage//:distributed-closure",
 	"@stackage//:text",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/osthreads/BUILD.bazel
+++ b/apps/osthreads/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "osthreads-hs",
-  linkstatic = False,
   srcs = ["osthreads.hs"],
   deps = [
     "//:sparkle-lib",
@@ -23,7 +22,6 @@ haskell_binary(
 	"@stackage//:streaming",
 	"@stackage//:text",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/apps/rdd-ops/BUILD.bazel
+++ b/apps/rdd-ops/BUILD.bazel
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load(
   "@rules_haskell//haskell:defs.bzl",
-  "haskell_binary",
+  "haskell_library",
 )
 
 load("@//:sparkle.bzl", "sparkle_package")
 
-haskell_binary(
+haskell_library(
   name = "rdd-ops",
-  linkstatic = False,
   srcs = ["RDDOps.hs"],
   deps = [
     "//:sparkle-lib",
@@ -17,7 +16,6 @@ haskell_binary(
 	"@stackage//:distributed-closure",
 	"@stackage//:text",
   ],
-  compiler_flags = ["-threaded", "-pie"],
 )
 
 sparkle_package(

--- a/hs-wrapper/FFIWrapper.hs
+++ b/hs-wrapper/FFIWrapper.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module FFIWrapper where
+
+import qualified Main
+
+foreign export ccall ioTweagSparkleMain :: IO ()
+
+ioTweagSparkleMain :: IO ()
+ioTweagSparkleMain = Main.main

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -3,7 +3,7 @@
 #
 # by going to a commit before the one introducing the regression.
 args:
-let pkgs = import (fetchTarball "https://github.com/tweag/nixpkgs/archive/76318102e1177a235ff38872cf4dfb2fc9590a42.tar.gz") args;
+let pkgs = import (fetchTarball "https://github.com/tweag/nixpkgs/archive/46113713d4f25579e07b78116a61ab6f178f4153.tar.gz") args;
 
     spark = pkgs.spark.override {
       # TODO: Some part/dependency of spark is unable to cope with newer

--- a/snapshot-9.0.1.yaml
+++ b/snapshot-9.0.1.yaml
@@ -1,18 +1,9 @@
-resolver: nightly-2021-01-27
-compiler: ghc-9.0.0.20201227
+resolver: nightly-2021-06-21
 
 packages:
 - github: tweag/distributed-closure
   commit: b92e75ec81e646703c7bde4f578a7352ee34f1ad
 - github: ekmett/exceptions
   commit: d7b742dc129790778f7b6d3347af80c8d69f8fcd
-- github: haskell/vector
-  commit: d919ffc72043af0066674aeaa997919e22d2a00f
-- github: simonmar/async
-  commit: 83c2cfe727b9a17ec1cb7228455ee650fde1bc77
-- github: facundominguez/hashable
-  commit: a03e06b79e5de3ad6d39522e08d1db830dc2a145
-- github: haskell/primitive
-  commit: 87b50ced840b3b1adbd61fe709b2e042f06e6ff3
 - github: tweag/linear-base
-  commit: 5af88c64aa5d8ac338098c033ee21616fce087ff
+  commit: ec0b5aa6dc89f1d7c7e368b7387e363a5062e52d

--- a/sparkle.bzl
+++ b/sparkle.bzl
@@ -1,6 +1,7 @@
 """Helpers for sparkle packaging."""
 
 load("@io_tweag_clodl//clodl:clodl.bzl", "library_closure")
+load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 
 def _mangle_dir(name):
     """Creates a unique directory name from the repo name and package
@@ -14,9 +15,16 @@ def _mangle_dir(name):
 def sparkle_package(name, src, resource_jars=[], **kwargs):
   libclosure = "libclosure-%s" % name
   
+  haskell_library(
+	name = libclosure + "-hs-wrapper",
+	srcs = ["@io_tweag_sparkle//:hs-wrapper/FFIWrapper.hs"],
+	deps = [src, "@io_tweag_sparkle//:base"],
+    compiler_flags = ["-threaded", "-flink-rts"],
+  )
+
   library_closure(
     name = libclosure,
-    srcs = [src],
+    srcs = [libclosure + "-hs-wrapper"],
     excludes = [
       "^/System/",
       "^/usr/lib/",


### PR DESCRIPTION
Because glibc dropped support for -pie, when upgrading nixpkgs we had to change how clodl deals with haskell code. Instead of using binaries, we load haskell libraries which expose a C interface.