### PR TITLE
Update clodl to correctly rebuild closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 * Fixed sparkle packaging in some ubuntus. (#149)
+* Fixed rebuild of closures (#157)
 
 ### Removed
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,9 @@ http_archive(
 
 http_archive(
   name = "io_tweag_clodl",
-  sha256 = "eb0025edbd4f36d55d2af2e87ac7c10c5adead44ebb05330a4a56391924c3efa",
-  strip_prefix = "clodl-20d27c8373c53b51a9d578c6d56a8691656078e3",
-  urls = ["https://github.com/tweag/clodl/archive/20d27c8373c53b51a9d578c6d56a8691656078e3.tar.gz"]
+  sha256 = "8bc8adf725f1d9be757dd5e2d7e2784eec10e1458bfc77ec75f322e7128df7e1",
+  strip_prefix = "clodl-9fed528a1950e4bf6e1e1ec8ba19efcebc34a630",
+  urls = ["https://github.com/tweag/clodl/archive/9fed528a1950e4bf6e1e1ec8ba19efcebc34a630.tar.gz"]
 )
 
 http_archive(

--- a/sparkle.bzl
+++ b/sparkle.bzl
@@ -15,8 +15,9 @@ def _mangle_dir(name):
 def sparkle_package(name, src, resource_jars=[], **kwargs):
   libclosure = "libclosure-%s" % name
   
+  libclosure_hs_wrapper = libclosure + "-hs-wrapper"
   haskell_library(
-	name = libclosure + "-hs-wrapper",
+	name = libclosure_hs_wrapper,
 	srcs = ["@io_tweag_sparkle//:hs-wrapper/FFIWrapper.hs"],
 	deps = [src, "@io_tweag_sparkle//:base"],
     compiler_flags = ["-threaded", "-flink-rts"],
@@ -24,7 +25,7 @@ def sparkle_package(name, src, resource_jars=[], **kwargs):
 
   library_closure(
     name = libclosure,
-    srcs = [libclosure + "-hs-wrapper"],
+    srcs = [libclosure_hs_wrapper],
     excludes = [
       "^/System/",
       "^/usr/lib/",
@@ -49,7 +50,7 @@ def sparkle_package(name, src, resource_jars=[], **kwargs):
     **kwargs
   )
 
-  libclosure_renamed = "libclosure-%s-renamed"
+  libclosure_renamed = libclosure + "-renamed"
   native.genrule(
     name = libclosure_renamed,
     srcs = [libclosure],


### PR DESCRIPTION
Without this PR we would fail to repackage Haskell applications when they are changed after a build.
https://github.com/tweag/clodl/pull/41