### PR TITLE
Call sparkle_hs_init in executors

### DIFF
--- a/cbits/bootstrap.c
+++ b/cbits/bootstrap.c
@@ -164,6 +164,9 @@ JNIEXPORT void JNICALL Java_io_tweag_sparkle_Sparkle_initializeHaskellRTS
 
 		// Deallocate resources from above.
 		free(hs_argv);
+
+		sparkle_hs_init();
+
 cleanup_initializeHaskellRTS:
 		for (jsize i = 0; i < jargc; i++)
 			free(cargs[i]);


### PR DESCRIPTION
This reverts the effect of 4c289498 which I think is causing multi-node setups to never load classes generated by inline-java, even with the provisions in the README to use a custom kryo registrator.

This was detected when studying the failure reported in #161.